### PR TITLE
fix: import elision for inline type specifiers, declare property decorators, and computed keys

### DIFF
--- a/crates/oxc_angular_compiler/src/component/import_elision.rs
+++ b/crates/oxc_angular_compiler/src/component/import_elision.rs
@@ -1677,6 +1677,13 @@ class MyComponent {
             "GridstackComponent on declare property should be elided"
         );
 
+        // ViewChild is only used as decorator on a `declare` property — must also be elided.
+        // TypeScript does not emit `declare` properties, so the decorator has no runtime effect.
+        assert!(
+            type_only.contains("ViewChild"),
+            "ViewChild decorator on declare property should be elided"
+        );
+
         // GridstackModule is used in Component imports array — must NOT be elided
         assert!(
             !type_only.contains("GridstackModule"),


### PR DESCRIPTION
Three import specifier mismatches fixed:
1. Inline `type` specifiers (`import { type FormGroup }`) now tracked and elided
2. `declare` property decorator args (`@ViewChild(X) declare y`) now elided
3. Computed property keys in type annotations (`[fromEmail]: T`) now preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes elision rules that directly affect emitted JS/TS imports, so mistakes could drop needed runtime imports or keep extra ones in Angular transforms.
> 
> **Overview**
> **Improves import elision accuracy** in `ImportElisionAnalyzer` to match TypeScript/Angular behavior for several previously misclassified patterns.
> 
> Inline `import { type X }` specifiers are now *always* treated as elidable even when mixed with value imports, `declare` property decorators (and their arguments) are treated as compiler-only uses eligible for elision, and a new post-pass preserves imports referenced via *computed property keys* inside type annotations (e.g. `{ [fromEmail]: string }`).
> 
> Adds regression tests covering these scenarios, including nested/union/array/tuple/parenthesized type shapes for computed keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fc59c61ca28d91715f04f9125fbed9195854597. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->