### PR TITLE
fix: check compound expressions in `needs_temporary_in_safe_access` for safe navigation

### DIFF
--- a/crates/oxc_angular_compiler/src/pipeline/phases/expand_safe_reads.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/expand_safe_reads.rs
@@ -127,10 +127,10 @@ pub fn expand_safe_reads(job: &mut ComponentCompilationJob<'_>) {
 
 /// Checks if an IR expression requires a temporary variable to avoid re-evaluation.
 ///
-/// Returns true for expressions with side effects:
-/// - Function calls/invocations
-/// - Pipe bindings
-/// - Safe function invocations
+/// Returns true for expressions with side effects (function calls, pipe bindings),
+/// or for compound expressions that may contain such sub-expressions.
+///
+/// Ported from Angular's `needsTemporaryInSafeAccess` in `expand_safe_reads.ts` lines 43-73.
 fn needs_temporary_in_safe_access(expr: &IrExpression<'_>) -> bool {
     match expr {
         // Function calls always need temporaries (they may have side effects)
@@ -140,6 +140,26 @@ fn needs_temporary_in_safe_access(expr: &IrExpression<'_>) -> bool {
         // Pipe bindings need temporaries (they may have side effects)
         IrExpression::PipeBinding(_) => true,
         IrExpression::PipeBindingVariadic(_) => true,
+        // Array and object literals need temporaries
+        IrExpression::LiteralArray(_) | IrExpression::DerivedLiteralArray(_) => true,
+        IrExpression::LiteralMap(_) | IrExpression::DerivedLiteralMap(_) => true,
+        // Unary operators need to check their operand
+        IrExpression::Unary(u) => needs_temporary_in_safe_access(&u.expr),
+        IrExpression::Not(n) => needs_temporary_in_safe_access(&n.expr),
+        // Binary operators need to check both operands
+        IrExpression::Binary(binary) => {
+            needs_temporary_in_safe_access(&binary.lhs)
+                || needs_temporary_in_safe_access(&binary.rhs)
+        }
+        IrExpression::ResolvedBinary(rb) => {
+            needs_temporary_in_safe_access(&rb.left) || needs_temporary_in_safe_access(&rb.right)
+        }
+        // Conditional expressions need to check all branches
+        IrExpression::Ternary(t) => {
+            needs_temporary_in_safe_access(&t.condition)
+                || needs_temporary_in_safe_access(&t.true_expr)
+                || needs_temporary_in_safe_access(&t.false_expr)
+        }
         // AssignTemporary expressions need to check their inner expression
         IrExpression::AssignTemporary(assign) => needs_temporary_in_safe_access(&assign.expr),
         // Safe property reads need to check their receiver

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -4374,3 +4374,67 @@ export class TestComponent {
     assert!(code.contains("i18n_0"), "Should have i18n_0 variable. Output:\n{code}");
     assert!(code.contains("i18n_1"), "Should have i18n_1 variable. Output:\n{code}");
 }
+
+/// Test that pipe inside binary expression with safe navigation generates a temporary variable.
+///
+/// When a pipe result is wrapped in a binary expression (e.g., `(data$ | async) || fallback`)
+/// and then used with safe navigation (`?.`), the compiler should generate a temporary variable
+/// to avoid calling the pipe twice.
+///
+/// This is a port of the Angular TS behavior where `needsTemporaryInSafeAccess` checks through
+/// `BinaryOperatorExpr` to find nested pipe expressions that need temporaries.
+///
+/// Without the fix, the compiler generates:
+///   `(pipeBind1(...) || fallback) == null ? null : (pipeBind1(...) || fallback).prop`
+///   (pipe called twice, slot indices doubled)
+///
+/// With the fix:
+///   `(tmp_0_0 = pipeBind1(...) || fallback) == null ? null : tmp_0_0.prop`
+///   (pipe called once, stored in temp variable)
+#[test]
+fn test_pipe_in_binary_with_safe_nav_uses_temp_variable() {
+    let js = compile_template_to_js(
+        r#"<div [title]="((data$ | async) || defaultVal)?.name"></div>"#,
+        "TestComponent",
+    );
+    eprintln!("OUTPUT:\n{js}");
+
+    // Should use a temporary variable to avoid double pipe evaluation
+    assert!(
+        js.contains("tmp_0_0"),
+        "Should generate tmp_0_0 for pipe inside binary with safe nav. Output:\n{js}"
+    );
+
+    // The pipe should only appear ONCE in the expression (stored in tmp)
+    let pipe_count = js.matches("pipeBind1(").count();
+    assert_eq!(
+        pipe_count, 1,
+        "pipeBind1 should appear exactly once (not duplicated). Found {pipe_count} occurrences. Output:\n{js}"
+    );
+}
+
+/// Test pipe in binary with safe navigation and chained property access.
+///
+/// More complex case: `((data$ | async) || fallback)?.nested?.value`
+/// The entire safe navigation chain should use the temp variable.
+#[test]
+fn test_pipe_in_binary_with_safe_nav_chain() {
+    let js = compile_template_to_js(
+        r#"<div [title]="((data$ | async) || defaultVal)?.nested?.value"></div>"#,
+        "TestComponent",
+    );
+    eprintln!("OUTPUT:\n{js}");
+
+    // Should use a temporary variable
+    assert!(
+        js.contains("tmp_0_0"),
+        "Should generate tmp_0_0 for pipe inside binary with safe nav chain. Output:\n{js}"
+    );
+
+    // The pipe should only appear ONCE
+    let pipe_count = js.matches("pipeBind1(").count();
+    assert_eq!(
+        pipe_count, 1,
+        "pipeBind1 should appear exactly once. Found {pipe_count}. Output:\n{js}"
+    );
+}


### PR DESCRIPTION
When a pipe expression is wrapped in a compound expression (binary, ternary, unary, not) and then accessed with safe navigation (`?.`), the compiler must generate a temporary variable to avoid re-evaluating the pipe. Previously, these compound expression types fell through to the default `false` case, causing the pipe to be called twice and doubling slot indices.

Add missing match arms for Binary, ResolvedBinary, Ternary, Unary, Not, LiteralArray, and LiteralMap to recursively check for side-effecting sub-expressions, matching the Angular TS reference implementation (`expand_safe_reads.ts` lines 43-73).

Fixes 7 mismatched files in ClickUp comparison (22 → 15, 99.62% → 99.74%).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core safe-navigation lowering and changes when temporaries are introduced, which can affect generated code shape and var/slot allocation across templates; behavior is covered by new regression tests but impacts a widely-used compilation phase.
> 
> **Overview**
> Fixes `expand_safe_reads` temporary-variable generation so safe navigation guards wrapped in *compound IR expressions* (unary/not, binary/resolved-binary, ternary, plus array/map literals) are recursively inspected for side effects like pipes/calls.
> 
> Adds integration coverage ensuring `((data$ | async) || fallback)?.prop` (and chained variants) emits a `tmp_*` and only a single `pipeBind1(...)`, matching Angular’s behavior and avoiding duplicated pipe evaluation/slot drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0bce1c7e8ddd7b1e91bacc8e091b12b00d562fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->