### PR TITLE
fix: setClassMetadata generates namespace-prefixed types for @Inject params with different type annotations

### DIFF
--- a/crates/oxc_angular_compiler/src/class_metadata/builders.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/builders.rs
@@ -10,7 +10,7 @@ use oxc_ast::ast::{
 };
 use oxc_span::Atom;
 
-use crate::component::{NamespaceRegistry, R3DependencyMetadata};
+use crate::component::{ImportMap, NamespaceRegistry, R3DependencyMetadata};
 use crate::output::ast::{
     ArrowFunctionBody, ArrowFunctionExpr, LiteralArrayExpr, LiteralExpr, LiteralMapEntry,
     LiteralMapExpr, LiteralValue, OutputExpression, ReadPropExpr, ReadVarExpr,
@@ -121,6 +121,7 @@ pub fn build_ctor_params_metadata<'a>(
     class: &Class<'a>,
     constructor_deps: Option<&[R3DependencyMetadata<'a>]>,
     namespace_registry: &mut NamespaceRegistry<'a>,
+    import_map: &ImportMap<'a>,
 ) -> Option<OutputExpression<'a>> {
     // Find constructor
     let constructor = class.body.body.iter().find_map(|element| {
@@ -144,6 +145,7 @@ pub fn build_ctor_params_metadata<'a>(
             param,
             constructor_deps.and_then(|deps| deps.get(i)),
             namespace_registry,
+            import_map,
         )
         .unwrap_or_else(|| {
             OutputExpression::Literal(Box::new_in(
@@ -278,16 +280,17 @@ pub fn build_prop_decorators_metadata<'a>(
 /// TypeScript type annotations are erased at runtime, so imported types need namespace
 /// imports (e.g., `i1.SomeService`) to be available as runtime values.
 ///
-/// The `dep.token_source_module` tracks where the injection token comes from. We only
-/// use it for namespace prefix when the type annotation name matches the dep token name,
-/// confirming that the dep's source module applies to the type. When they differ
-/// (e.g., `@Inject(DOCUMENT) doc: Document`), we fall back to bare name since the type
-/// may be a global or from a different module.
+/// When the type annotation name matches the dep token name, the dep's `token_source_module`
+/// is used directly. When they differ (e.g., `@Inject(DARK_THEME) theme$: Observable<boolean>`),
+/// we look up the type annotation name in the `import_map` to find its source module
+/// independently. This matches Angular's behavior where type references in `setClassMetadata`
+/// always use namespace-prefixed imports regardless of whether `@Inject` is used.
 fn build_param_type_expression<'a>(
     allocator: &'a Allocator,
     param: &FormalParameter<'a>,
     dep: Option<&R3DependencyMetadata<'a>>,
     namespace_registry: &mut NamespaceRegistry<'a>,
+    import_map: &ImportMap<'a>,
 ) -> Option<OutputExpression<'a>> {
     // Extract the type name from the type annotation
     let type_name = extract_param_type_name(param);
@@ -323,7 +326,39 @@ fn build_param_type_expression<'a>(
         }
     }
 
+    // When the type annotation differs from the dep token (e.g., @Inject(TOKEN) param: SomeType),
+    // look up the type annotation name in the import_map to find its source module independently.
+    // Only generate namespace-prefixed references for non-type-only imports, since type-only
+    // imports (`import type { X }` / `import { type X }`) are erased at runtime and don't
+    // resolve to values. Angular's compiler uses typeToValue() which skips interfaces and
+    // type aliases; checking is_type_only is the closest heuristic without a full type checker.
+    if let Some(ref tn) = type_name {
+        if let Some(import_info) = import_map.get(tn) {
+            if import_info.is_type_only {
+                // Type-only imports are erased at runtime — emit undefined.
+                return None;
+            }
+            let namespace = namespace_registry.get_or_assign(&import_info.source_module);
+            return Some(OutputExpression::ReadProp(Box::new_in(
+                ReadPropExpr {
+                    receiver: Box::new_in(
+                        OutputExpression::ReadVar(Box::new_in(
+                            ReadVarExpr { name: namespace, source_span: None },
+                            allocator,
+                        )),
+                        allocator,
+                    ),
+                    name: tn.clone(),
+                    optional: false,
+                    source_span: None,
+                },
+                allocator,
+            )));
+        }
+    }
+
     // Fall back to extracting the bare type name from the type annotation
+    // (for local/global types not in the import_map)
     extract_param_type_expression(allocator, param)
 }
 

--- a/crates/oxc_angular_compiler/src/component/cross_file_elision.rs
+++ b/crates/oxc_angular_compiler/src/component/cross_file_elision.rs
@@ -93,18 +93,18 @@ impl CrossFileAnalyzer {
         import_name: &str,
         from_file: &Path,
     ) -> bool {
-        // Skip node_modules - assume they export values (conservative)
-        if import_source.starts_with('@') || !import_source.starts_with('.') {
-            // Package imports - check cache first
-            // For @angular/core, @bitwarden/common, etc., we cannot easily analyze
-            // Return false (conservative - assume value) unless we've already cached it
-            return false;
-        }
-
         // Resolve the import path to a file
         let resolved = match from_file.parent() {
             Some(parent) => match self.resolver.resolve(parent, import_source) {
-                Ok(resolution) => resolution.full_path().to_string_lossy().to_string(),
+                Ok(resolution) => {
+                    let full_path = resolution.full_path();
+                    // Skip node_modules - pre-compiled packages don't have interface
+                    // declarations visible in their source. Assume value (conservative).
+                    if full_path.components().any(|c| c.as_os_str() == "node_modules") {
+                        return false;
+                    }
+                    full_path.to_string_lossy().to_string()
+                }
                 Err(_) => return false, // Cannot resolve - assume value (conservative)
             },
             None => return false,

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 
 use oxc_allocator::{Allocator, Vec as OxcVec};
 use oxc_ast::ast::{
-    Declaration, ExportDefaultDeclarationKind, ImportDeclarationSpecifier, Statement,
+    Declaration, ExportDefaultDeclarationKind, ImportDeclarationSpecifier, ImportOrExportKind,
+    Statement,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::Parser;
@@ -391,6 +392,10 @@ pub struct ImportInfo<'a> {
     /// True for: `import { AuthService } from "module"`
     /// False for: `import * as core from "module"` (namespace imports)
     pub is_named_import: bool,
+    /// Whether this is a type-only import (`import type { X }` or `import { type X }`).
+    /// Type-only imports are erased at runtime and should not generate namespace
+    /// imports for `setClassMetadata()` type references.
+    pub is_type_only: bool,
 }
 
 /// Map from local identifier name to its import information.
@@ -438,6 +443,9 @@ pub fn build_import_map<'a>(
 
         let default_source_module = import_decl.source.value.clone();
 
+        // `import type { ... }` makes all specifiers type-only
+        let decl_is_type_only = import_decl.import_kind == ImportOrExportKind::Type;
+
         // Process all specifiers
         let Some(specifiers) = &import_decl.specifiers else {
             // Side-effect import: `import 'foo'` - no identifiers to map
@@ -453,14 +461,21 @@ pub fn build_import_map<'a>(
                     // Named imports CAN be reused with bare name
                     let local_name = spec.local.name.clone();
 
+                    // Type-only if the declaration is `import type { ... }` or the specifier
+                    // is `import { type X }` (inline type specifier)
+                    let is_type_only =
+                        decl_is_type_only || spec.import_kind == ImportOrExportKind::Type;
+
                     // Check if we have a resolved path for this identifier
                     let source_module = resolved_imports
                         .and_then(|m| m.get(local_name.as_str()))
                         .map(|resolved| Atom::from(allocator.alloc_str(resolved)))
                         .unwrap_or_else(|| default_source_module.clone());
 
-                    import_map
-                        .insert(local_name, ImportInfo { source_module, is_named_import: true });
+                    import_map.insert(
+                        local_name,
+                        ImportInfo { source_module, is_named_import: true, is_type_only },
+                    );
                 }
                 ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
                     // Default import: `import DefaultService from "module"`
@@ -473,8 +488,14 @@ pub fn build_import_map<'a>(
                         .map(|resolved| Atom::from(allocator.alloc_str(resolved)))
                         .unwrap_or_else(|| default_source_module.clone());
 
-                    import_map
-                        .insert(local_name, ImportInfo { source_module, is_named_import: true });
+                    import_map.insert(
+                        local_name,
+                        ImportInfo {
+                            source_module,
+                            is_named_import: true,
+                            is_type_only: decl_is_type_only,
+                        },
+                    );
                 }
                 ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
                     // Namespace import: `import * as core from "module"`
@@ -487,8 +508,14 @@ pub fn build_import_map<'a>(
                         .map(|resolved| Atom::from(allocator.alloc_str(resolved)))
                         .unwrap_or_else(|| default_source_module.clone());
 
-                    import_map
-                        .insert(local_name, ImportInfo { source_module, is_named_import: false });
+                    import_map.insert(
+                        local_name,
+                        ImportInfo {
+                            source_module,
+                            is_named_import: false,
+                            is_type_only: decl_is_type_only,
+                        },
+                    );
                 }
             }
         }
@@ -590,19 +617,17 @@ pub fn transform_angular_file(
     // by tracking the next index and passing it to each component.
     let mut shared_pool_index: u32 = 0;
 
-    // When cross_file_elision is enabled, resolve import paths through barrel exports
-    // to get the actual source file paths. This is merged with any externally-provided
-    // resolved_imports from the options.
+    // When cross_file_elision is enabled, collect type-only information for each import
+    // by checking if the exported symbol is an interface or type alias. This is separate
+    // from barrel resolution to avoid changing namespace import paths.
     #[cfg(feature = "cross_file_elision")]
-    let resolved_imports_for_build = if options.cross_file_elision {
+    let cross_file_type_only: FxHashMap<String, bool> = if options.cross_file_elision {
         let file_path = std::path::Path::new(path);
         let base_dir = options.base_dir.as_deref().or_else(|| file_path.parent());
 
         if let Some(base) = base_dir {
             let mut analyzer = CrossFileAnalyzer::new(base, options.tsconfig_path.as_deref());
-
-            // Build resolved imports map by tracing each named import through barrel exports
-            let mut resolved = options.resolved_imports.clone().unwrap_or_default();
+            let mut type_only: FxHashMap<String, bool> = FxHashMap::default();
 
             for stmt in &parser_ret.program.body {
                 let Statement::ImportDeclaration(import_decl) = stmt else {
@@ -619,40 +644,49 @@ pub fn transform_angular_file(
                         let local_name = spec.local.name.as_str();
                         let imported_name = spec.imported.name().as_str();
 
-                        // Skip if already resolved externally
-                        if resolved.contains_key(local_name) {
-                            continue;
-                        }
-
-                        // Try to resolve the import path through barrel exports
-                        if let Some(resolved_path) =
-                            analyzer.resolve_import_source_path(source, imported_name, file_path)
-                        {
-                            // Only add if the resolved path is different from the original
-                            if resolved_path != source {
-                                resolved.insert(local_name.to_string(), resolved_path);
-                            }
+                        // Check if this import is type-only using the original import path.
+                        // Resolves the file and checks if the exported symbol is an interface
+                        // or type alias. Unresolvable imports return false (conservative).
+                        if analyzer.is_type_only_import(source, imported_name, file_path) {
+                            type_only.insert(local_name.to_string(), true);
                         }
                     }
                 }
             }
 
-            Some(resolved)
+            type_only
         } else {
-            options.resolved_imports.clone()
+            FxHashMap::default()
         }
     } else {
-        options.resolved_imports.clone()
+        FxHashMap::default()
     };
 
+    // Build import map from import declarations using ORIGINAL import paths.
+    // Only externally-provided resolved_imports (e.g., for host directives) override paths.
+    // Barrel-resolved paths are NOT used here to avoid changing namespace import paths
+    // from what Angular's compiler would produce.
     #[cfg(not(feature = "cross_file_elision"))]
-    let resolved_imports_for_build = options.resolved_imports.clone();
-
-    // Build import map from import declarations
-    // This maps imported identifiers to their source modules
-    // When resolved_imports is provided, it overrides barrel export paths with actual file paths
     let import_map =
-        build_import_map(allocator, &parser_ret.program.body, resolved_imports_for_build.as_ref());
+        build_import_map(allocator, &parser_ret.program.body, options.resolved_imports.as_ref());
+
+    #[cfg(feature = "cross_file_elision")]
+    let mut import_map =
+        build_import_map(allocator, &parser_ret.program.body, options.resolved_imports.as_ref());
+
+    // Apply cross-file type-only information to the import_map.
+    // This marks imports that resolve to interfaces or type aliases as type-only,
+    // even when they don't use `import type` syntax. This is needed because many
+    // codebases import interfaces with regular `import { X }` syntax, and without
+    // a TypeScript type checker we cannot otherwise distinguish interfaces from classes.
+    #[cfg(feature = "cross_file_elision")]
+    for (name, is_type_only) in &cross_file_type_only {
+        if let Some(info) = import_map.get_mut(name.as_str()) {
+            if *is_type_only {
+                info.is_type_only = true;
+            }
+        }
+    }
 
     // 2. Walk AST to find @Component decorated classes and extract metadata
     for stmt in &parser_ret.program.body {
@@ -795,6 +829,7 @@ pub fn transform_angular_file(
                                             class,
                                             ctor_deps_slice,
                                             &mut file_namespace_registry,
+                                            &import_map,
                                         ),
                                         prop_decorators: build_prop_decorators_metadata(
                                             allocator, class,
@@ -4013,18 +4048,184 @@ export class ButtonComponent {}
             result.code
         );
 
-        // The output should contain the RESOLVED path, not the barrel path
-        // i.e., `../a11y/aria-disable.directive` not `../a11y`
+        // The output should use the ORIGINAL import path (barrel path), matching Angular's behavior.
+        // Angular's compiler uses original import paths, not barrel-resolved paths.
         assert!(
-            result.code.contains("'../a11y/aria-disable.directive'"),
-            "Code should import from resolved path '../a11y/aria-disable.directive', but got:\n{}",
+            result.code.contains("'../a11y'"),
+            "Code should import from original barrel path '../a11y', but got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_inject_decorator_with_different_type_module_generates_namespace_import() {
+        // When @Inject(TOKEN) is used and the type annotation comes from a different module
+        // than the token, setClassMetadata should emit a namespace-prefixed type reference
+        // and generate the namespace import for the type's module.
+        //
+        // Example: @Inject(DARK_THEME) darkTheme$: Observable<boolean>
+        //   - Token: DARK_THEME from '@app/theme'
+        //   - Type: Observable from 'rxjs'
+        //   - Expected: { type: i2.Observable, decorators: [{ type: Inject, args: [DARK_THEME] }] }
+        //   - Expected import: import * as i2 from "rxjs"
+        let allocator = Allocator::default();
+        let source = r#"
+import { Component, Inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { DARK_THEME } from '@app/theme';
+
+@Component({
+    selector: 'app-test',
+    template: '<div></div>'
+})
+export class TestComponent {
+    constructor(
+        @Inject(DARK_THEME) protected readonly darkTheme$: Observable<boolean>,
+    ) {}
+}
+"#;
+
+        let mut options = TransformOptions::default();
+        options.emit_class_metadata = true;
+
+        let result =
+            transform_angular_file(&allocator, "test.component.ts", source, &options, None);
+
+        // Should generate namespace import for rxjs (i1 because i0=@angular/core;
+        // DARK_THEME uses bare name via @Inject so @app/theme doesn't get a namespace)
+        assert!(
+            result.code.contains("import * as i1 from 'rxjs'"),
+            "Should generate namespace import for rxjs, but got:\n{}",
             result.code
         );
 
-        // The output should NOT contain a namespace import for just the barrel path
+        // The setClassMetadata ctor params should reference i1.Observable
         assert!(
-            !result.code.contains("import * as i1 from '../a11y';"),
-            "Code should NOT have namespace import from barrel path '../a11y', but got:\n{}",
+            result.code.contains("i1.Observable"),
+            "setClassMetadata should use namespace-prefixed Observable, but got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_inject_decorator_with_service_type_from_different_module() {
+        // Similar to the Observable case but with a service type:
+        // @Inject(TOKEN) service: AbstractService
+        // where TOKEN is from one module and AbstractService is from another.
+        let allocator = Allocator::default();
+        let source = r#"
+import { Component, Inject } from '@angular/core';
+import { AbstractService, SERVICE_TOKEN } from './service';
+import { Store } from '@ngrx/store';
+
+@Component({
+    selector: 'app-test',
+    template: '<div></div>'
+})
+export class TestComponent {
+    constructor(
+        @Inject(SERVICE_TOKEN) private readonly service: AbstractService,
+        private readonly store: Store,
+    ) {}
+}
+"#;
+
+        let mut options = TransformOptions::default();
+        options.emit_class_metadata = true;
+
+        let result =
+            transform_angular_file(&allocator, "test.component.ts", source, &options, None);
+
+        // The type 'AbstractService' is imported from './service' and should get a namespace import
+        // even though the @Inject token 'SERVICE_TOKEN' is also from './service'.
+        // The factory generates i1 for @ngrx/store (Store), so ./service should get i2
+        // for the metadata type reference.
+        assert!(
+            result.code.contains("i1.Store") || result.code.contains("i2.Store"),
+            "Should generate namespace-prefixed Store reference, but got:\n{}",
+            result.code
+        );
+
+        // AbstractService should get a namespace-prefixed reference in metadata
+        // (the exact index depends on registration order, but it must be namespace-prefixed)
+        assert!(
+            result.code.contains("i1.AbstractService")
+                || result.code.contains("i2.AbstractService"),
+            "setClassMetadata should use namespace-prefixed AbstractService, but got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_inject_decorator_with_type_only_import_skips_namespace() {
+        // When the type annotation is from a type-only import (`import type { X }`),
+        // setClassMetadata should NOT generate a namespace import for it because
+        // type-only imports are erased at runtime and don't resolve to values.
+        // Angular's compiler uses typeToValue() which returns null for interfaces/types.
+        let allocator = Allocator::default();
+        let source = r#"
+import { Component, Inject, InjectionToken } from '@angular/core';
+import type { SomeInterface } from './some.interface';
+
+const MY_TOKEN = new InjectionToken<SomeInterface>('my-token');
+
+@Component({
+    selector: 'app-test',
+    template: '<div></div>'
+})
+export class TestComponent {
+    constructor(
+        @Inject(MY_TOKEN) private readonly data: SomeInterface,
+    ) {}
+}
+"#;
+
+        let mut options = TransformOptions::default();
+        options.emit_class_metadata = true;
+
+        let result =
+            transform_angular_file(&allocator, "test.component.ts", source, &options, None);
+
+        // Should NOT generate a namespace import for ./some.interface
+        // (the original `import type` statement may still appear, but no `import * as iN`)
+        assert!(
+            !result.code.contains("import * as i1 from './some.interface'"),
+            "Should NOT generate namespace import for type-only import, but got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_inject_decorator_with_inline_type_specifier_skips_namespace() {
+        // Same as above but with inline type specifier: `import { type X } from '...'`
+        let allocator = Allocator::default();
+        let source = r#"
+import { Component, Inject, InjectionToken } from '@angular/core';
+import { type SomeInterface } from './some.interface';
+
+const MY_TOKEN = new InjectionToken<SomeInterface>('my-token');
+
+@Component({
+    selector: 'app-test',
+    template: '<div></div>'
+})
+export class TestComponent {
+    constructor(
+        @Inject(MY_TOKEN) private readonly data: SomeInterface,
+    ) {}
+}
+"#;
+
+        let mut options = TransformOptions::default();
+        options.emit_class_metadata = true;
+
+        let result =
+            transform_angular_file(&allocator, "test.component.ts", source, &options, None);
+
+        // Should NOT generate a namespace import for ./some.interface
+        assert!(
+            !result.code.contains("import * as i1 from './some.interface'"),
+            "Should NOT generate namespace import for inline type-only import, but got:\n{}",
             result.code
         );
     }

--- a/napi/angular-compiler/e2e/compare/src/compilers/oxc.ts
+++ b/napi/angular-compiler/e2e/compare/src/compilers/oxc.ts
@@ -114,6 +114,8 @@ export interface OxcFullFileRawOutput {
 export interface OxcFullFileRawOptions {
   /** Pre-resolved external resources (templates/styles) */
   resolvedResources?: ResolvedResources | null
+  /** Path to tsconfig.json for resolving path aliases in cross-file analysis */
+  tsconfigPath?: string
 }
 
 /**
@@ -143,6 +145,8 @@ export function compileWithOxcFullFileRaw(
     // Enable cross-file analysis for barrel export tracing
     crossFileElision: true,
     baseDir: path.dirname(filePath),
+    // Pass tsconfig for resolving monorepo path aliases (e.g., @cu/*)
+    tsconfigPath: options?.tsconfigPath,
     // Enable class metadata for TestBed support (matches Angular's output)
     emitClassMetadata: true,
   }
@@ -300,6 +304,8 @@ export async function compileClassMetadataWithOxc(
 export interface OxcProjectOptions {
   /** Pre-resolved resources (templates/styles) by file path */
   resolvedResourcesByFile?: Map<string, PlainResolvedResources>
+  /** Path to tsconfig.json for resolving path aliases in cross-file analysis */
+  tsconfigPath?: string
 }
 
 /**
@@ -337,6 +343,7 @@ export function compileProjectWithOxc(
         const plainResources = options?.resolvedResourcesByFile?.get(filePath)
         const compiled = compileWithOxcFullFileRaw(source, filePath, {
           resolvedResources: plainResources,
+          tsconfigPath: options?.tsconfigPath,
         })
 
         if (compiled.error) {

--- a/napi/angular-compiler/e2e/compare/src/runner.ts
+++ b/napi/angular-compiler/e2e/compare/src/runner.ts
@@ -206,6 +206,7 @@ async function compareFilesProjectWide(
   const oxcStartTime = performance.now()
   const oxcResult = compileProjectWithOxc(filePaths, fileContents, {
     resolvedResourcesByFile,
+    tsconfigPath: config.tsconfigPath,
   })
   const oxcDuration = performance.now() - oxcStartTime
   console.log(

--- a/napi/angular-compiler/src/lib.rs
+++ b/napi/angular-compiler/src/lib.rs
@@ -1932,8 +1932,14 @@ pub fn compile_class_metadata_sync(
     // and namespace registry), so imported types won't get namespace prefixes.
     // The full transform_angular_file pipeline handles namespace prefixes correctly.
     let mut namespace_registry = oxc_angular_compiler::NamespaceRegistry::new(&allocator);
-    let ctor_params_expr =
-        core_build_ctor_params_metadata(&allocator, class, None, &mut namespace_registry);
+    let empty_import_map = oxc_angular_compiler::ImportMap::default();
+    let ctor_params_expr = core_build_ctor_params_metadata(
+        &allocator,
+        class,
+        None,
+        &mut namespace_registry,
+        &empty_import_map,
+    );
 
     // Build property decorators metadata
     let prop_decorators_expr = core_build_prop_decorators_metadata(&allocator, class);


### PR DESCRIPTION
When a constructor parameter uses `@Inject(TOKEN) param: SomeType`, the type annotation (SomeType) differs from the dep token (TOKEN). Previously only the token was checked for namespace prefixing, leaving the type annotation as a bare reference. Now the import map is consulted to generate `i1.SomeType` for imported types, while skipping type-only imports that have no runtime value.

Also extends CrossFileAnalyzer to resolve monorepo package imports via tsconfig path aliases (skipping node_modules), and separates barrel resolution from type-only detection to avoid path mismatches with Angular's output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `setClassMetadata()` ctor-parameter type emission and import handling; incorrect classification of type-only/value imports could change generated JS imports or metadata at runtime.
> 
> **Overview**
> Fixes `setClassMetadata()` constructor-parameter metadata so that when `@Inject(TOKEN)` is used with a different type annotation, the *type* now resolves via the file `import_map` and emits namespace-prefixed references (e.g. `iN.Observable`) instead of a bare identifier.
> 
> Extends `ImportMap` to track `import type`/inline type specifiers (and, with `cross_file_elision`, marks interface/type-alias imports as type-only via cross-file export analysis), avoiding namespace imports for erased type-only symbols and keeping namespace import paths aligned with Angular (prefer original import paths over barrel-resolved ones). Also threads an optional `tsconfigPath` through the NAPI e2e runner to support path-alias resolution during cross-file analysis, and adds targeted tests for the new metadata/import behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 482f70e76a9cf769c644e7264f04f409d016634e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->