### PR TITLE
fix(angular): preserve class name binding for export after IIFE wrapping

### DIFF
--- a/crates/oxc_angular_compiler/src/optimizer/adjust_static_members.rs
+++ b/crates/oxc_angular_compiler/src/optimizer/adjust_static_members.rs
@@ -231,7 +231,7 @@ impl AdjustStaticMembersTransformer {
         // Determine if we need to extract the variable declaration part
         // Pattern: let X = class X {} -> we wrap the class expression and assignments
         let (var_prefix, class_expr_start, class_expr_end) =
-            self.extract_var_declaration_parts(start_span, source)?;
+            self.extract_var_declaration_parts(start_span, source, group.class_name)?;
 
         // Build the wrapped code
         let mut wrapped = String::new();
@@ -287,6 +287,7 @@ impl AdjustStaticMembersTransformer {
         &self,
         stmt_span: Span,
         source: &str,
+        class_name: &str,
     ) -> Option<(String, u32, u32)> {
         let stmt_text = &source[stmt_span.start as usize..stmt_span.end as usize];
 
@@ -324,7 +325,10 @@ impl AdjustStaticMembersTransformer {
             }
         } else {
             // It's a class declaration: class X {}
-            return Some((String::new(), stmt_span.start, stmt_span.end));
+            // We must assign the IIFE result to a variable so the class name
+            // remains in scope for subsequent export statements.
+            let var_prefix = format!("let {} = ", class_name);
+            return Some((var_prefix, stmt_span.start, stmt_span.end));
         }
 
         None

--- a/crates/oxc_angular_compiler/tests/adjust_static_members_test.rs
+++ b/crates/oxc_angular_compiler/tests/adjust_static_members_test.rs
@@ -414,3 +414,26 @@ ClassB.ɵfac = factoryB;
 
     test_wrap_static(input, &["/* @__PURE__ */ (() =>", "return ClassA;", "return ClassB;"], &[]);
 }
+
+#[test]
+fn test_class_declaration_preserves_binding_for_export() {
+    // Regression test: class declarations (not variable declarations) must
+    // produce `let X = /* @__PURE__ */ (() => { ... })()` so the name remains
+    // in scope for subsequent `export { X }` statements.
+    let input = r"
+class ClipboardModule {}
+ClipboardModule.ɵfac = function ClipboardModule_Factory(t) { return new (t || ClipboardModule)(); };
+ClipboardModule.ɵmod = defineNgModule({ type: ClipboardModule });
+export { ClipboardModule };
+";
+
+    test_wrap_static(
+        input,
+        &[
+            "let ClipboardModule = /* @__PURE__ */ (() =>",
+            "return ClipboardModule;",
+            "export { ClipboardModule }",
+        ],
+        &[],
+    );
+}


### PR DESCRIPTION
Class declarations (e.g. `class X {}`) were being wrapped in an IIFE
without assigning the result, causing the class name to fall out of
scope for subsequent `export { X }` statements. Now emits
`let X = /* @__PURE__ */ (() => { ... })()` for class declarations.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized codegen change plus a regression test; main risk is unintended output differences for class-declaration wrapping edge cases.
> 
> **Overview**
> Fixes the static-members optimizer so wrapping a *class declaration* (`class X {}`) in a pure IIFE now assigns the IIFE result back to a binding (`let X = /* @__PURE__ */ (() => { ... })()`), preserving the identifier for later `export { X }`.
> 
> Updates `extract_var_declaration_parts` to accept the class name and synthesize the `let X =` prefix for declaration-form classes, and adds a regression test covering the `export { ClipboardModule }` case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca13ec86f0183eb7eb6745a54e425d3779477a0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->