### PR TITLE
fix(angular): fix 3 compiler divergences from Angular reference

### DIFF
--- a/crates/oxc_angular_compiler/src/ir/ops.rs
+++ b/crates/oxc_angular_compiler/src/ir/ops.rs
@@ -1228,8 +1228,9 @@ pub struct RepeaterVarNames<'a> {
     pub item: Option<Atom<'a>>,
     /// Alias for $count.
     pub count: Option<Atom<'a>>,
-    /// Alias for $index.
-    pub index: Option<Atom<'a>>,
+    /// Aliases for $index (can be multiple, e.g. `let i = $index, j = $index`).
+    /// Angular stores these in a `Set<string>`.
+    pub index: Vec<'a, Atom<'a>>,
     /// Alias for $first.
     pub first: Option<Atom<'a>>,
     /// Alias for $last.

--- a/crates/oxc_angular_compiler/src/pipeline/ingest.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/ingest.rs
@@ -2502,10 +2502,11 @@ fn ingest_for_block<'a>(
     });
 
     // Build var_names for the repeater, tracking user-defined aliases
+    #[allow(clippy::needless_update)]
     let mut var_names = RepeaterVarNames {
         item: Some(for_block.item.name.clone()),
         count: None,
-        index: None,
+        index: oxc_allocator::Vec::new_in(allocator),
         first: None,
         last: None,
         even: None,
@@ -2525,7 +2526,7 @@ fn ingest_for_block<'a>(
     // This is used for track expression variable replacement
     for var in for_block.context_variables.iter() {
         if var.value.as_str() == "$index" {
-            var_names.index = Some(var.name.clone());
+            var_names.index.push(var.name.clone());
         }
     }
 

--- a/crates/oxc_angular_compiler/src/pipeline/phases/track_variables.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/track_variables.rs
@@ -37,10 +37,7 @@ pub fn generate_track_variables(job: &mut ComponentCompilationJob<'_>) {
             if let CreateOp::RepeaterCreate(rep) = op {
                 // Get $index names and $implicit name for this repeater
                 let index_names: Vec<Atom<'_>> = {
-                    let mut names = Vec::new();
-                    if let Some(ref index) = rep.var_names.index {
-                        names.push(index.clone());
-                    }
+                    let mut names: Vec<Atom<'_>> = rep.var_names.index.iter().cloned().collect();
                     // Also include '$index' itself
                     names.push(Atom::from("$index"));
                     names

--- a/crates/oxc_angular_compiler/src/transform/control_flow.rs
+++ b/crates/oxc_angular_compiler/src/transform/control_flow.rs
@@ -531,9 +531,9 @@ fn parse_let_parameter<'a>(
         }
 
         // Check for duplicate alias name
-        let already_has_name = context_variables
-            .iter()
-            .any(|v| v.name.as_str() == name && v.name.as_str() != v.value.as_str());
+        // Angular checks all existing names including implicit context vars (e.g. $index).
+        // Reference: r3_control_flow.ts line 479
+        let already_has_name = context_variables.iter().any(|v| v.name.as_str() == name);
         if already_has_name {
             errors.push(format!("Duplicate \"let\" parameter variable \"{}\"", variable_name));
             current_offset += part.len() as u32 + 1;

--- a/crates/oxc_angular_compiler/src/transform/html_to_r3.rs
+++ b/crates/oxc_angular_compiler/src/transform/html_to_r3.rs
@@ -2370,12 +2370,19 @@ impl<'a> HtmlToR3Transform<'a> {
             }
 
             // Validate @case: must have exactly one parameter
+            // Angular pushes invalid @case blocks into unknownBlocks for language service support.
+            // Reference: r3_control_flow.ts line 242
             let is_case = child_block.block_type == BlockType::Case;
             if is_case && child_block.parameters.len() != 1 {
                 self.report_error(
                     "@case block must have exactly one parameter",
                     child_block.start_span,
                 );
+                unknown_blocks.push(crate::ast::r3::R3UnknownBlock {
+                    name: child_block.name.clone(),
+                    source_span: child_block.span,
+                    name_span: child_block.name_span,
+                });
                 continue;
             }
 

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -5126,3 +5126,27 @@ export class MixedQueryComponent {
         }
     }
 }
+
+#[test]
+fn test_for_loop_multiple_index_aliases_in_track() {
+    // When multiple aliases reference $index (e.g., `let i = $index, j = $index`),
+    // ALL aliases must be rewritten to $index in the track expression.
+    // Angular stores all $index aliases in a Set<string> and checks membership,
+    // while a bug in OXC previously stored only the last alias (overwriting earlier ones).
+    // Reference: Angular's ingest.ts uses `indexVarNames = new Set<string>()` and `.add()`.
+    let js = compile_template_to_js(
+        r#"@for (item of items; track i + j; let i = $index, j = $index) { {{item}} }"#,
+        "TestComponent",
+    );
+    // The track function should rewrite both `i` and `j` to `$index`.
+    // Expected: ($index,$item)=>($index + $index)
+    // Bug behavior: ($index,$item)=>(this.i + $index)  (only `j` rewritten, `i` left as `this.i`)
+    assert!(
+        !js.contains("this.i"),
+        "Track expression should rewrite all $index aliases, but `i` was not rewritten.\nGenerated JS:\n{js}"
+    );
+    assert!(
+        !js.contains("this.j"),
+        "Track expression should rewrite all $index aliases, but `j` was not rewritten.\nGenerated JS:\n{js}"
+    );
+}

--- a/crates/oxc_angular_compiler/tests/r3_template_transform_test.rs
+++ b/crates/oxc_angular_compiler/tests/r3_template_transform_test.rs
@@ -2052,3 +2052,77 @@ mod switch_validation {
         );
     }
 }
+
+// ============================================================================
+// Tests: @for duplicate let parameter validation
+// ============================================================================
+
+mod switch_invalid_case_unknown_blocks {
+    use super::*;
+
+    /// Helper that parses HTML to R3 AST and returns the unknown_blocks from the first SwitchBlock.
+    fn get_switch_unknown_block_names(html: &str) -> Vec<String> {
+        let allocator = Box::new(Allocator::default());
+        let allocator_ref: &'static Allocator =
+            unsafe { &*std::ptr::from_ref::<Allocator>(allocator.as_ref()) };
+
+        let parser = HtmlParser::new(allocator_ref, html, "test.html");
+        let html_result = parser.parse();
+
+        let options = TransformOptions { collect_comment_nodes: false };
+        let transformer = HtmlToR3Transform::new(allocator_ref, html, options);
+        let r3_result = transformer.transform(&html_result.nodes);
+
+        // Find the first SwitchBlock and return its unknown_blocks names
+        for node in r3_result.nodes.iter() {
+            if let R3Node::SwitchBlock(b) = node {
+                return b.unknown_blocks.iter().map(|ub| ub.name.to_string()).collect();
+            }
+        }
+        Vec::new()
+    }
+
+    #[test]
+    fn should_add_invalid_case_with_no_params_to_unknown_blocks() {
+        // Angular pushes @case blocks with invalid parameters into unknownBlocks
+        // for language service autocompletion support.
+        // Reference: r3_control_flow.ts line 242
+        let unknown_names =
+            get_switch_unknown_block_names("@switch (expr) { @case { a } @case (1) { b } }");
+        assert!(
+            unknown_names.contains(&"case".to_string()),
+            "Expected invalid @case (no params) to be in unknown_blocks, got: {unknown_names:?}"
+        );
+    }
+}
+
+mod for_loop_duplicate_let_validation {
+    use super::*;
+
+    #[test]
+    fn should_report_duplicate_let_for_implicit_var_aliased_to_itself() {
+        // Angular test: `let $index = $index` should be rejected as a duplicate
+        // because $index is already pre-populated as an implicit context variable.
+        // Reference: r3_template_transform_spec.ts line 2340
+        let errors = get_transform_errors(
+            "@for (item of items.foo.bar; track item.id; let $index = $index) {}",
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("Duplicate \"let\" parameter variable")),
+            "Expected duplicate let parameter error for `let $index = $index`, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn should_report_duplicate_let_for_explicit_alias_used_twice() {
+        // Angular test: `let i = $index` used twice should be rejected
+        // Reference: r3_template_transform_spec.ts line 2340
+        let errors = get_transform_errors(
+            "@for (item of items.foo.bar; track item.id; let i = $index, f = $first, i = $index) {}",
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("Duplicate \"let\" parameter variable")),
+            "Expected duplicate let parameter error for duplicate alias `i`, got: {errors:?}"
+        );
+    }
+}


### PR DESCRIPTION
1. @for duplicate `let` validation: Remove extra `name != value` condition
   that skipped implicit context variables, causing `let $index = $index`
   to be silently accepted instead of rejected as a duplicate.

2. $index alias handling: Change `RepeaterVarNames.index` from `Option<Atom>`
   to `Vec<Atom>` so multiple aliases for $index (e.g. `let i = $index,
   j = $index`) are all stored and rewritten in track expressions, matching
   Angular's `Set<string>` behavior.

3. @switch invalid @case unknown_blocks: Push invalid @case blocks (wrong
   parameter count) into `unknown_blocks` before continuing, matching
   Angular's behavior for language service autocompletion support.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-flow transform and repeater track-expression rewriting, which can change generated output and error surfaces for `@for`/`@switch` templates. Changes are narrow and covered by new regression tests.
> 
> **Overview**
> Aligns `@for` parsing/ingestion with Angular by treating *any* repeated `let` name as a duplicate (including implicit context vars like `$index`), so invalid declarations now error instead of being accepted.
> 
> Fixes repeater `$index` alias tracking by storing **all** aliases (not just one) and using them when rewriting `track` expressions, ensuring multiple `$index` aliases are correctly transformed.
> 
> Updates `@switch` transformation so invalid `@case` blocks (wrong parameter count) are still recorded in `unknown_blocks` before being skipped, matching Angular’s language-service behavior. Adds focused regression tests for these cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c69647e569db487a871332d56c6adb12ae6c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->