### PR TITLE
fix: linker emits unique constant names when component has both ng-content and host styles

### DIFF
--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -1989,12 +1989,14 @@ pub fn compile_template_to_js_with_options<'a>(
     }
 
     // Stage 6: Compile host bindings if provided via options
+    let host_pool_starting_index = job.pool.next_name_index();
     if let Some(ref host_input) = options.host {
         if let Some(host_result) = compile_host_bindings_from_input(
             allocator,
             host_input,
             component_name,
             options.selector.as_deref(),
+            host_pool_starting_index,
         ) {
             // Add host binding pool declarations (pure functions, etc.)
             for decl in host_result.declarations {
@@ -2556,6 +2558,7 @@ fn compile_host_bindings_from_input<'a>(
     host_input: &HostMetadataInput,
     component_name: &str,
     selector: Option<&str>,
+    pool_starting_index: u32,
 ) -> Option<HostBindingCompilationResult<'a>> {
     use oxc_allocator::FromIn;
 
@@ -2576,10 +2579,9 @@ fn compile_host_bindings_from_input<'a>(
         selector.map(|s| Atom::from_in(s, allocator)).unwrap_or_else(|| Atom::from(""));
 
     // Convert to HostBindingInput and compile
-    // Use 0 as starting index since this is standalone compilation (not part of a larger file)
     let input =
         convert_host_metadata_to_input(allocator, &host, component_name_atom, component_selector);
-    let mut job = ingest_host_binding(allocator, input, 0);
+    let mut job = ingest_host_binding(allocator, input, pool_starting_index);
     let result = compile_host_bindings(&mut job);
 
     Some(result)
@@ -2605,10 +2607,16 @@ pub fn compile_host_bindings_for_linker(
     host_input: &HostMetadataInput,
     component_name: &str,
     selector: Option<&str>,
+    pool_starting_index: u32,
 ) -> Option<LinkerHostBindingOutput> {
     let allocator = Allocator::default();
-    let result =
-        compile_host_bindings_from_input(&allocator, host_input, component_name, selector)?;
+    let result = compile_host_bindings_from_input(
+        &allocator,
+        host_input,
+        component_name,
+        selector,
+        pool_starting_index,
+    )?;
 
     let emitter = JsEmitter::new();
 
@@ -2653,6 +2661,10 @@ pub struct LinkerTemplateOutput {
 
     /// The ngContentSelectors array as a JavaScript expression string, if any.
     pub ng_content_selectors_js: Option<String>,
+
+    /// The next available pool index after template compilation.
+    /// Used to continue constant numbering in host binding compilation.
+    pub next_pool_index: u32,
 }
 
 /// Compile a template for the linker, returning all data needed to build a `defineComponent` call.
@@ -2824,6 +2836,7 @@ pub fn compile_template_for_linker<'a>(
     }
 
     let declarations_js = emitter.emit_statements(&all_statements);
+    let next_pool_index = job.pool.next_name_index();
 
     Ok(LinkerTemplateOutput {
         declarations_js,
@@ -2832,6 +2845,7 @@ pub fn compile_template_for_linker<'a>(
         vars,
         consts_js,
         ng_content_selectors_js,
+        next_pool_index,
     })
 }
 

--- a/crates/oxc_angular_compiler/src/linker/mod.rs
+++ b/crates/oxc_angular_compiler/src/linker/mod.rs
@@ -1399,9 +1399,12 @@ fn link_component(
         // through the full Angular expression parser for correct output.
         let host_input = extract_host_metadata_input(host_obj);
         let selector = get_string_property(meta, "selector");
-        if let Some(host_output) =
-            crate::component::compile_host_bindings_for_linker(&host_input, type_name, selector)
-        {
+        if let Some(host_output) = crate::component::compile_host_bindings_for_linker(
+            &host_input,
+            type_name,
+            selector,
+            template_output.next_pool_index,
+        ) {
             if host_output.host_vars > 0 {
                 parts.push(format!("hostVars: {}", host_output.host_vars));
             }
@@ -1972,6 +1975,63 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "
         assert!(
             !result.code.contains("\u{0275}\u{0275}ngDeclareComponent"),
             "Should not contain ngDeclareComponent, got:\n{}",
+            result.code
+        );
+    }
+
+    /// Regression test for https://github.com/voidzero-dev/oxc-angular-compiler/issues/59
+    /// When a component has both <ng-content> (which pools a `_c0` constant for selectors)
+    /// and a host style binding (which pools a `_c0` constant for the style factory),
+    /// the linker must use unique names (`_c0`, `_c1`) instead of duplicating `_c0`.
+    #[test]
+    fn test_link_component_ng_content_with_host_style_no_duplicate_constants() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+class MyCheckbox {
+  static ɵfac = i0.ɵɵngDeclareFactory({
+    minVersion: "12.0.0", version: "19.2.8", ngImport: i0,
+    type: MyCheckbox, deps: [], target: i0.ɵɵFactoryTarget.Component
+  });
+  static ɵcmp = i0.ɵɵngDeclareComponent({
+    minVersion: "14.0.0", version: "19.2.8", ngImport: i0,
+    type: MyCheckbox, isStandalone: true, selector: "my-checkbox",
+    host: {
+      properties: { "style": "{display: \"contents\"}" }
+    },
+    template: `<button><ng-content /></button>`,
+    isInline: true,
+    changeDetection: i0.ChangeDetectionStrategy.OnPush
+  });
+}
+
+export { MyCheckbox };
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Component should be linked");
+        assert!(
+            result.code.contains("defineComponent"),
+            "Should contain defineComponent, got:\n{}",
+            result.code
+        );
+        // Must not have duplicate _c0 declarations
+        let c0_count = result.code.matches("const _c0").count();
+        assert!(
+            c0_count <= 1,
+            "Should not have duplicate 'const _c0' declarations (found {c0_count}), got:\n{}",
+            result.code
+        );
+        // Should have both ngContentSelectors and hostBindings
+        assert!(
+            result.code.contains("ngContentSelectors"),
+            "Should contain ngContentSelectors, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("hostBindings"),
+            "Should contain hostBindings, got:\n{}",
             result.code
         );
     }


### PR DESCRIPTION
The linker's host binding compilation now continues from the template's
pool index instead of restarting at 0, preventing duplicate `_c0`
declarations when a component has both `<ng-content>` and host style
bindings.

- Close https://github.com/voidzero-dev/oxc-angular-compiler/issues/59

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Angular codegen/linker constant-pooling by threading pool indices across compilation stages; mistakes could change emitted JS identifiers and break linked output for some components.
> 
> **Overview**
> Ensures host-binding compilation *continues the template’s constant pool numbering* instead of restarting at `0`, preventing duplicate `const _c0` (e.g., when `<ng-content>` and host style bindings both need pooled constants).
> 
> This threads a `pool_starting_index` through `compile_host_bindings_from_input`/`compile_host_bindings_for_linker`, adds `next_pool_index` to `LinkerTemplateOutput`, updates the linker to pass it into host-binding compilation, and adds a regression test for issue #59 covering the ng-content + host style case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8ab59dbe03f8583f52d43a017f214019e3bc1d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->