### PR TITLE
fix: linker converts providers/usesInheritance/usesOnChanges to features for directives

### DIFF
--- a/crates/oxc_angular_compiler/src/linker/mod.rs
+++ b/crates/oxc_angular_compiler/src/linker/mod.rs
@@ -1050,7 +1050,7 @@ fn link_directive(
     if let Some(host_directives) = get_property_source(meta, "hostDirectives", source) {
         parts.push(format!("hostDirectives: {host_directives}"));
     }
-    if let Some(features) = get_property_source(meta, "features", source) {
+    if let Some(features) = build_features(meta, source, ns) {
         parts.push(format!("features: {features}"));
     }
 
@@ -2087,6 +2087,93 @@ class EmptyOutletComponent {
         assert!(
             result.code.contains("dependencies: [RouterOutlet]"),
             "Should extract dependency types, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_directive_with_providers() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class BrnTooltipTrigger {
+}
+BrnTooltipTrigger.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "20.0.0", ngImport: i0, type: BrnTooltipTrigger, selector: "[brnTooltipTrigger]", isStandalone: true, providers: [BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER] });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            result.code.contains("ProvidersFeature"),
+            "Should have ProvidersFeature for directive providers, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER"),
+            "Should preserve provider reference, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_directive_with_uses_inheritance() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyDirective {
+}
+MyDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "20.0.0", ngImport: i0, type: MyDirective, selector: "[myDir]", isStandalone: true, usesInheritance: true });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            result.code.contains("InheritDefinitionFeature"),
+            "Should have InheritDefinitionFeature, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_directive_with_uses_on_changes() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyDirective {
+}
+MyDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "20.0.0", ngImport: i0, type: MyDirective, selector: "[myDir]", isStandalone: true, usesOnChanges: true });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            result.code.contains("NgOnChangesFeature"),
+            "Should have NgOnChangesFeature, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_directive_with_all_features() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyDirective {
+}
+MyDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "20.0.0", ngImport: i0, type: MyDirective, selector: "[myDir]", isStandalone: true, providers: [SomeService], usesInheritance: true, usesOnChanges: true });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            result.code.contains("ProvidersFeature"),
+            "Should have ProvidersFeature, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("InheritDefinitionFeature"),
+            "Should have InheritDefinitionFeature, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("NgOnChangesFeature"),
+            "Should have NgOnChangesFeature, got:\n{}",
             result.code
         );
     }


### PR DESCRIPTION
The directive linker was passing through a raw `features` property that
doesn't exist on partial declarations. Replace with `build_features()`
(already used by the component linker) so `providers`, `usesInheritance`,
and `usesOnChanges` are correctly converted to their feature equivalents.

- Close https://github.com/voidzero-dev/oxc-angular-compiler/issues/66

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes directive codegen in the Angular partial declaration linker, which can affect runtime behavior if feature emission is incorrect, but the change is small and covered by new focused tests.
> 
> **Overview**
> Fixes directive linking to *compute* the `features` array via `build_features()` (matching component linking) so directive partial declarations with `providers`, `usesInheritance`, and/or `usesOnChanges` emit the correct feature calls (e.g. `ɵɵProvidersFeature`, `ɵɵInheritDefinitionFeature`, `ɵɵNgOnChangesFeature`).
> 
> Adds regression tests covering each directive feature flag and the combined case to ensure provider references are preserved and the expected feature helpers appear in linked output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c946b5c19720335db0537f76708039ca409d4dbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->