### PR TITLE
chore: upgrade oxc_* dependencies from 0.110 to 0.116

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -69,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -121,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -163,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "dragonbox_ecma"
-version = "0.1.0"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5577f010d4e1bb3f3c4d6081e05718eb6992cf20119cab4d3abadff198b5ae"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "dtor"
@@ -212,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "fast-glob"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d26eec0ae9682c457cb0f85de67ad417b716ae852736a5d94c2ad6e92a997c9"
+checksum = "3b9e81515b0279bf618200fd15d132e7195d2048fb46eed6f0f3c10cbc068266"
 dependencies = [
  "arrayvec",
 ]
@@ -227,9 +233,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -239,6 +245,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -257,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -272,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -282,15 +294,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -299,15 +311,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -316,21 +328,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -340,27 +352,27 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "globset"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -375,7 +387,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -386,8 +407,14 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
@@ -471,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,16 +531,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.46.1"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248b42847813a1550dafd15296fd9748c651d0c32194559dbc05d804d54b21e8"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console",
  "globset",
@@ -548,10 +581,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -576,24 +615,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -603,9 +633,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc-safe"
@@ -618,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.2"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909805cbad4d569e69b80e101290fe72e92b9742ba9e333b0c1e83b22fb7447b"
+checksum = "e6944d0bf100571cd6e1a98a316cdca262deb6fccf8d93f5ae1502ca3fc88bd3"
 dependencies = [
  "bitflags",
  "ctor",
@@ -640,9 +670,9 @@ checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ba21bbdf40b33496b4ee6eadfc64d17a6a6cde57cd31549117b0882d1fef86"
+checksum = "2c914b5e420182bfb73504e0607592cdb8e2e21437d450883077669fb72a114d"
 dependencies = [
  "convert_case",
  "ctor",
@@ -654,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.1"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a63791e230572c3218a7acd86ca0a0529fc64294bcbea567cf906d7b04e077"
+checksum = "f0864cf6a82e2cfb69067374b64c9253d7e910e5b34db833ed7495dda56ccb18"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -734,9 +764,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc-miette"
@@ -766,12 +796,12 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2174c7c8f77137b1bd1c653d7a5a531ae41f3b8fec1dd0251c801689784e7a2e"
+checksum = "93d4e5a43018728a7f6aa14b1034c43a0869fc0d05002a181d5dacc698e488b9"
 dependencies = [
  "allocator-api2",
- "hashbrown",
+ "hashbrown 0.16.1",
  "oxc_data_structures",
  "oxc_estree",
  "rustc-hash",
@@ -833,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f1902f97a5cac8767b76a1d8a1b3124e9db80c176ebbc98f75143dcc124a15"
+checksum = "12b7429c1035c3bf0de582ae4458d4f769566d574cfe71e170e328a123337a8d"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -850,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a31bd55516a98a35b2d99fa5813a3d3a5b798bad3262c819dfe7344bc6f390"
+checksum = "1d3d3eb4a7b45c9f407f96ecafddad0a88cbf085dca7d74f3e4191ba03d2d5f3"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -862,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c520a488c04ba5267223edd0bb245fb7f10e2358e8955802a5d962bb95b50a"
+checksum = "87408c66c769e714cc74c24626403c63b0fd76f251d0971404a347611280668d"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -874,15 +904,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42840ce8d83a08a92823dda6189e4d97359feca24a4fa732f3256c4614bb5a4"
+checksum = "af06d9ab1bfd8baff16ef7dcc6824ea1fea0938ba41b1e113b882738e285d8ee"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f7b09c1563a67ede53af131f717b31ba89a992959ebad188b5158c21d4dc0a"
+checksum = "908b7dae769982c7ade68f6ba3b4edb32b5a5941800fe8118f9c96fe4cfa7982"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -891,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4813b352bd5b0b05badf0c9e6c5ec7ea58a6a7ab49bec8d18ead262624c6ef8d"
+checksum = "78e4efa8dd802bb4e15536c71b081540f7bf4fc046b7043bc2e650cea40f62ca"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -907,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54fb3effe995e6538d68070bf0a450b5ffd11dd41b62f11a4d01efa1f40e278"
+checksum = "f5e33d1f099a1e5c8f820df64654b1657f0aaf744d4137377726902738bfba80"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -928,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7d7902d9fadf224ad77fd8c4d5f9787d8cc5911ba6c94d8edea1117aa8660b"
+checksum = "d08b7a5df70f84534f362d08f38535260f0d68ec8b1bd0e3ca80a4c6d1389f30"
 dependencies = [
  "napi",
  "napi-build",
@@ -944,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5592bf8b64743944eb46528f9eabdde2b2435c8293cd502f5c183f9dff644e16"
+checksum = "fa019a6d043e2087d8506c6716a55ee680ffb3eb564ab52bed0328d4076afb33"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -967,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09de7f7e0fb82f54750e3a95346a828fd354b9aeac00f131719008733e66a18d"
+checksum = "0f28f7617dc3d0dd642ca4f9be4c8cf5365f114dc27a745d1ebfa82b8f729ef3"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -983,18 +1013,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "11.16.4"
+version = "11.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903284699f550838a491118e58e9d9adb4941c2514f148aedff1ce4b4fbd578"
+checksum = "5632fcd47d4fdaf7ef5ee150c7001fa8ed814ce38d1a073536a366dbfc239aad"
 dependencies = [
  "cfg-if",
+ "compact_str",
  "fast-glob",
  "indexmap",
  "json-strip-comments",
  "nodejs-built-in-modules",
  "once_cell",
  "papaya",
- "parking_lot",
  "rustc-hash",
  "rustix",
  "self_cell",
@@ -1010,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2269186b4f1510a76daf02914cb70e82a78549de451b8276bba0a419c62ac3"
+checksum = "c5ab63f46cfbf4ef58b5a78439202593fe4a8511281ba1de32303e2c28b0e5e8"
 dependencies = [
  "itertools",
  "memchr",
@@ -1032,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "6.0.1"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36801dbbd025f2fa133367494e38eef75a53d334ae6746ba0c889fc4e76fa3a3"
+checksum = "c7f89482522f3cd820817d48ee4ade5b10822060d6e5e4d419f05f6d8bd29d70"
 dependencies = [
  "base64-simd",
  "json-escape-simd",
@@ -1045,23 +1075,37 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a42c0759b745eca0fe776890af46ce12e79e61796995e51a8eb9dcdf5516ab0"
+checksum = "6813c0f28625a9a1c8906144396fb7ee22a2a7722d49b707a06d19f81be450ef"
 dependencies = [
  "compact_str",
  "oxc-miette",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",
+ "oxc_str",
+ "serde",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b163ab61908f1d636704bb57425692c38a7addde8e7244ff0dd92394084a17fe"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.16.1",
+ "oxc_allocator",
+ "oxc_estree",
  "serde",
 ]
 
 [[package]]
 name = "oxc_syntax"
-version = "0.110.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63eac2e04a75a10c5714aeb753cdfa06b1abc66bbaa748b7994700f52c9b184"
+checksum = "06c82e33172f5613c4b7cf502d90b4ea866cd9103cb5e818a938889aef847daf"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1069,7 +1113,6 @@ dependencies = [
  "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",
- "oxc_data_structures",
  "oxc_estree",
  "oxc_index",
  "oxc_span",
@@ -1086,29 +1129,6 @@ checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
 dependencies = [
  "equivalent",
  "seize",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -1174,15 +1194,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -1191,6 +1205,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1210,27 +1234,18 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ref-cast"
@@ -1254,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1265,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
@@ -1277,9 +1292,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1296,9 +1311,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1308,12 +1323,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seize"
@@ -1425,9 +1434,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1458,9 +1467,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1480,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1534,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "pin-project-lite",
 ]
@@ -1580,9 +1589,9 @@ checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1601,6 +1610,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -1655,6 +1670,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1863,6 +1921,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -1949,6 +2089,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,14 +87,14 @@ multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 # External oxc crates from crates.io
-oxc_allocator = "0.110"
-oxc_ast = "0.110"
-oxc_ast_visit = "0.110"
-oxc_diagnostics = "0.110"
-oxc_napi = "0.110"
-oxc_parser = "0.110"
-oxc_semantic = "0.110"
-oxc_span = "0.110"
+oxc_allocator = "0.116"
+oxc_ast = "0.116"
+oxc_ast_visit = "0.116"
+oxc_diagnostics = "0.116"
+oxc_napi = "0.116"
+oxc_parser = "0.116"
+oxc_semantic = "0.116"
+oxc_span = "0.116"
 oxc_sourcemap = "6.0.1"
 
 # Internal

--- a/crates/oxc_angular_compiler/src/class_metadata/builders.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/builders.rs
@@ -33,7 +33,7 @@ pub fn build_decorator_metadata_array<'a>(
         let type_expr = match &decorator.expression {
             Expression::CallExpression(call) => match &call.callee {
                 Expression::Identifier(id) => Some(OutputExpression::ReadVar(Box::new_in(
-                    ReadVarExpr { name: id.name, source_span: None },
+                    ReadVarExpr { name: id.name.into(), source_span: None },
                     allocator,
                 ))),
                 Expression::StaticMemberExpression(member) => {
@@ -42,7 +42,7 @@ pub fn build_decorator_metadata_array<'a>(
                         OutputExpression::ReadProp(Box::new_in(
                             ReadPropExpr {
                                 receiver: Box::new_in(receiver, allocator),
-                                name: member.property.name,
+                                name: member.property.name.into(),
                                 optional: false,
                                 source_span: None,
                             },
@@ -53,7 +53,7 @@ pub fn build_decorator_metadata_array<'a>(
                 _ => None,
             },
             Expression::Identifier(id) => Some(OutputExpression::ReadVar(Box::new_in(
-                ReadVarExpr { name: id.name, source_span: None },
+                ReadVarExpr { name: id.name.into(), source_span: None },
                 allocator,
             ))),
             _ => None,
@@ -370,8 +370,8 @@ fn extract_param_type_name<'a>(param: &FormalParameter<'a>) -> Option<Atom<'a>> 
     let type_annotation = param.type_annotation.as_ref()?;
     match &type_annotation.type_annotation {
         TSType::TSTypeReference(type_ref) => match &type_ref.type_name {
-            TSTypeName::IdentifierReference(id) => Some(id.name),
-            TSTypeName::QualifiedName(qualified) => Some(qualified.right.name),
+            TSTypeName::IdentifierReference(id) => Some(id.name.into()),
+            TSTypeName::QualifiedName(qualified) => Some(qualified.right.name.into()),
             TSTypeName::ThisExpression(_) => None,
         },
         _ => None,
@@ -394,12 +394,12 @@ fn extract_param_type_expression<'a>(
             // Handle simple type references like SomeService
             match &type_ref.type_name {
                 TSTypeName::IdentifierReference(id) => Some(OutputExpression::ReadVar(
-                    Box::new_in(ReadVarExpr { name: id.name, source_span: None }, allocator),
+                    Box::new_in(ReadVarExpr { name: id.name.into(), source_span: None }, allocator),
                 )),
                 TSTypeName::QualifiedName(qualified) => {
                     // Handle qualified names like ns.SomeType
                     Some(OutputExpression::ReadVar(Box::new_in(
-                        ReadVarExpr { name: qualified.right.name, source_span: None },
+                        ReadVarExpr { name: qualified.right.name.into(), source_span: None },
                         allocator,
                     )))
                 }
@@ -446,7 +446,7 @@ fn get_decorator_name<'a>(decorator: &Decorator<'a>) -> Option<&'a str> {
 /// Get property key name as an Atom.
 fn get_property_key_name<'a>(key: &PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.into()),
         PropertyKey::StringLiteral(lit) => Some(lit.value),
         _ => None,
     }

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -52,7 +52,7 @@ pub fn extract_component_metadata<'a>(
     import_map: &ImportMap<'a>,
 ) -> Option<ComponentMetadata<'a>> {
     // Get the class name
-    let class_name = class.id.as_ref()?.name.clone();
+    let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
     let class_span = class.span;
 
     // Find the @Component decorator
@@ -336,7 +336,7 @@ fn is_component_call(callee: &Expression<'_>) -> bool {
 /// Get the name of a property key as a string.
 fn get_property_key_name<'a>(key: &PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.clone()),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.clone().into()),
         PropertyKey::StringLiteral(lit) => Some(lit.value.clone()),
         _ => None,
     }
@@ -405,7 +405,7 @@ fn extract_identifier_array<'a>(
     for element in &arr.elements {
         match element {
             ArrayExpressionElement::Identifier(id) => {
-                result.push(id.name.clone());
+                result.push(id.name.clone().into());
             }
             // Handle spread elements, etc. - for now just collect identifiers
             _ => {}
@@ -562,9 +562,10 @@ fn extract_single_host_directive<'a>(
     match element {
         // Simple identifier: TooltipDirective
         ArrayExpressionElement::Identifier(id) => {
-            let mut meta = HostDirectiveMetadata::new(allocator, id.name.clone());
+            let name: Atom<'a> = id.name.clone().into();
+            let mut meta = HostDirectiveMetadata::new(allocator, name.clone());
             // Look up the source module from the import map
-            if let Some(import_info) = import_map.get(&id.name) {
+            if let Some(import_info) = import_map.get(&name) {
                 meta.source_module = Some(import_info.source_module.clone());
             }
             Some(meta)
@@ -645,7 +646,7 @@ fn extract_single_host_directive<'a>(
 fn extract_directive_reference<'a>(expr: &Expression<'a>) -> (Option<Atom<'a>>, bool) {
     match expr {
         // Simple identifier: ColorDirective
-        Expression::Identifier(id) => (Some(id.name.clone()), false),
+        Expression::Identifier(id) => (Some(id.name.clone().into()), false),
 
         // ForwardRef call: forwardRef(() => ColorDirective)
         Expression::CallExpression(call) => {
@@ -692,7 +693,7 @@ fn extract_forward_ref_directive_name<'a>(arg: Option<&Argument<'a>>) -> Option<
                 body.statements.first()
             {
                 if let Expression::Identifier(id) = &stmt.expression {
-                    return Some(id.name.clone());
+                    return Some(id.name.clone().into());
                 }
             }
             None
@@ -967,11 +968,11 @@ fn extract_param_dependency<'a>(
 fn get_decorator_name<'a>(expr: &'a Expression<'a>) -> Option<Atom<'a>> {
     match expr {
         // @Optional
-        Expression::Identifier(id) => Some(id.name.clone()),
+        Expression::Identifier(id) => Some(id.name.clone().into()),
         // @Optional()
         Expression::CallExpression(call) => {
             if let Expression::Identifier(id) = &call.callee {
-                Some(id.name.clone())
+                Some(id.name.clone().into())
             } else {
                 None
             }
@@ -983,12 +984,12 @@ fn get_decorator_name<'a>(expr: &'a Expression<'a>) -> Option<Atom<'a>> {
 /// Extract the injection token from an @Inject decorator argument.
 fn extract_inject_token<'a>(arg: &'a Argument<'a>) -> Option<Atom<'a>> {
     match arg {
-        Argument::Identifier(id) => Some(id.name.clone()),
+        Argument::Identifier(id) => Some(id.name.clone().into()),
         _ => {
             // For other expressions, try to get the expression form
             let expr = arg.to_expression();
             match expr {
-                Expression::Identifier(id) => Some(id.name.clone()),
+                Expression::Identifier(id) => Some(id.name.clone().into()),
                 _ => None,
             }
         }
@@ -1005,7 +1006,7 @@ fn extract_param_token<'a>(param: &'a oxc_ast::ast::FormalParameter<'a>) -> Opti
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
         // Get the type name
         let type_name = match &type_ref.type_name {
-            oxc_ast::ast::TSTypeName::IdentifierReference(id) => Some(id.name.clone()),
+            oxc_ast::ast::TSTypeName::IdentifierReference(id) => Some(id.name.clone().into()),
             oxc_ast::ast::TSTypeName::QualifiedName(_)
             | oxc_ast::ast::TSTypeName::ThisExpression(_) => {
                 // Qualified names like Namespace.Type or 'this' type - not valid injection tokens

--- a/crates/oxc_angular_compiler/src/component/import_elision.rs
+++ b/crates/oxc_angular_compiler/src/component/import_elision.rs
@@ -92,11 +92,11 @@ impl<'a> ImportElisionAnalyzer<'a> {
                     ImportDeclarationSpecifier::ImportSpecifier(spec) => {
                         // Explicit type-only specifiers (import { type X }) are always elided
                         if spec.import_kind.is_type() {
-                            type_only_specifiers.insert(spec.local.name.clone());
+                            type_only_specifiers.insert(spec.local.name.clone().into());
                             continue;
                         }
 
-                        let name = &spec.local.name;
+                        let name: Atom<'a> = spec.local.name.clone().into();
 
                         // Check if this import has only type references
                         if Self::is_type_only_import(&spec.local, semantic) {
@@ -108,7 +108,7 @@ impl<'a> ImportElisionAnalyzer<'a> {
                         }
                     }
                     ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
-                        let name = &spec.local.name;
+                        let name: Atom<'a> = spec.local.name.clone().into();
 
                         if Self::is_type_only_import(&spec.local, semantic) {
                             type_only_specifiers.insert(name.clone());
@@ -119,7 +119,7 @@ impl<'a> ImportElisionAnalyzer<'a> {
                         // e.g., `import * as moment from 'moment'` where `moment` is only
                         // used in type annotations like `moment.Moment`.
                         if Self::is_type_only_import(&spec.local, semantic) {
-                            type_only_specifiers.insert(spec.local.name.clone());
+                            type_only_specifiers.insert(spec.local.name.clone().into());
                         }
                     }
                 }
@@ -273,12 +273,12 @@ impl<'a> ImportElisionAnalyzer<'a> {
     fn collect_idents_from_expression(expr: &'a Expression<'a>, result: &mut FxHashSet<Atom<'a>>) {
         match expr {
             Expression::Identifier(id) => {
-                result.insert(id.name.clone());
+                result.insert(id.name.clone().into());
             }
             Expression::StaticMemberExpression(member) => {
                 // For `RecipientType.To`, collect `RecipientType`
                 if let Expression::Identifier(id) = &member.object {
-                    result.insert(id.name.clone());
+                    result.insert(id.name.clone().into());
                 }
             }
             _ => {}
@@ -638,7 +638,7 @@ impl<'a> ImportElisionAnalyzer<'a> {
     }
 
     /// Check if a specifier name should be elided (removed).
-    pub fn should_elide(&self, name: &Atom<'a>) -> bool {
+    pub fn should_elide(&self, name: &str) -> bool {
         self.type_only_specifiers.contains(name)
     }
 
@@ -702,14 +702,14 @@ impl<'a> ImportElisionAnalyzer<'a> {
                     let local_name = &spec.local.name;
 
                     // Skip if already marked as type-only by semantic analysis
-                    if analyzer.type_only_specifiers.contains(local_name) {
+                    if analyzer.type_only_specifiers.contains(local_name.as_str()) {
                         continue;
                     }
 
                     // Check cross-file: is the export type-only in the source file?
                     let imported_name = spec.imported.name().as_str();
                     if cross_file_analyzer.is_type_only_import(source, imported_name, file_path) {
-                        analyzer.type_only_specifiers.insert(local_name.clone());
+                        analyzer.type_only_specifiers.insert(local_name.clone().into());
                     }
                 }
             }
@@ -769,7 +769,7 @@ pub fn filter_imports<'a>(
                 ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => &s.local.name,
                 ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => &s.local.name,
             };
-            !analyzer.should_elide(name)
+            !analyzer.should_elide(name.as_str())
         });
 
         if removed.is_empty() && !kept.is_empty() {

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -450,7 +450,7 @@ pub fn build_import_map<'a>(
                     // or aliased: `import { AuthService as Auth } from "module"`
                     // We use the local name as the key
                     // Named imports CAN be reused with bare name
-                    let local_name = spec.local.name.clone();
+                    let local_name: Atom<'a> = spec.local.name.clone().into();
 
                     // Type-only if the declaration is `import type { ... }` or the specifier
                     // is `import { type X }` (inline type specifier)
@@ -471,7 +471,7 @@ pub fn build_import_map<'a>(
                 ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
                     // Default import: `import DefaultService from "module"`
                     // Default imports CAN be reused with bare name
-                    let local_name = spec.local.name.clone();
+                    let local_name: Atom<'a> = spec.local.name.clone().into();
 
                     // Check if we have a resolved path for this identifier
                     let source_module = resolved_imports
@@ -491,7 +491,7 @@ pub fn build_import_map<'a>(
                 ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
                     // Namespace import: `import * as core from "module"`
                     // Namespace imports CANNOT be reused with bare name for individual symbols
-                    let local_name = spec.local.name.clone();
+                    let local_name: Atom<'a> = spec.local.name.clone().into();
 
                     // Check if we have a resolved path for this identifier
                     let source_module = resolved_imports

--- a/crates/oxc_angular_compiler/src/directive/decorator.rs
+++ b/crates/oxc_angular_compiler/src/directive/decorator.rs
@@ -79,7 +79,7 @@ pub fn extract_directive_metadata<'a>(
     implicit_standalone: bool,
 ) -> Option<R3DirectiveMetadata<'a>> {
     // Get the class name
-    let class_name = class.id.as_ref()?.name.clone();
+    let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
 
     // Find the @Directive decorator
     let directive_decorator = find_directive_decorator(&class.decorators)?;
@@ -357,11 +357,11 @@ fn extract_param_dependency<'a>(
 fn get_decorator_name_from_expr<'a>(expr: &'a Expression<'a>) -> Option<Atom<'a>> {
     match expr {
         // @Optional
-        Expression::Identifier(id) => Some(id.name.clone()),
+        Expression::Identifier(id) => Some(id.name.clone().into()),
         // @Optional()
         Expression::CallExpression(call) => {
             if let Expression::Identifier(id) = &call.callee {
-                Some(id.name.clone())
+                Some(id.name.clone().into())
             } else {
                 None
             }
@@ -388,7 +388,7 @@ fn extract_param_token<'a>(
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
         // Get the type name
         let type_name = match &type_ref.type_name {
-            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone(),
+            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone().into(),
             oxc_ast::ast::TSTypeName::QualifiedName(_)
             | oxc_ast::ast::TSTypeName::ThisExpression(_) => {
                 // Qualified names like Namespace.Type or 'this' type - not valid injection tokens
@@ -435,7 +435,7 @@ fn has_ng_on_changes_method(class: &Class<'_>) -> bool {
 /// Get the name of a property key as a string.
 fn get_property_key_name<'a>(key: &PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.clone()),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.clone().into()),
         PropertyKey::StringLiteral(lit) => Some(lit.value.clone()),
         _ => None,
     }
@@ -549,7 +549,7 @@ fn extract_single_host_directive<'a>(
     match element {
         // Simple identifier: TooltipDirective
         ArrayExpressionElement::Identifier(id) => Some(R3HostDirectiveMetadata {
-            directive: OutputAstBuilder::variable(allocator, id.name.clone()),
+            directive: OutputAstBuilder::variable(allocator, id.name.clone().into()),
             is_forward_reference: false,
             inputs: Vec::new_in(allocator),
             outputs: Vec::new_in(allocator),
@@ -623,7 +623,7 @@ fn extract_directive_reference<'a>(
     match expr {
         // Simple identifier: ColorDirective
         Expression::Identifier(id) => {
-            (Some(OutputAstBuilder::variable(allocator, id.name.clone())), false)
+            (Some(OutputAstBuilder::variable(allocator, id.name.clone().into())), false)
         }
 
         // ForwardRef call: forwardRef(() => ColorDirective)
@@ -663,7 +663,7 @@ fn extract_forward_ref_directive_name<'a>(arg: Option<&Argument<'a>>) -> Option<
                 body.statements.first()
             {
                 if let Expression::Identifier(id) = &stmt.expression {
-                    return Some(id.name.clone());
+                    return Some(id.name.clone().into());
                 }
             }
             None

--- a/crates/oxc_angular_compiler/src/directive/property_decorators.rs
+++ b/crates/oxc_angular_compiler/src/directive/property_decorators.rs
@@ -52,7 +52,7 @@ fn find_decorator_by_name<'a>(
 /// Handles both identifier keys and string literal keys.
 fn get_property_key_name<'a>(key: &PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.clone()),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.clone().into()),
         PropertyKey::StringLiteral(lit) => Some(lit.value.clone()),
         _ => None,
     }

--- a/crates/oxc_angular_compiler/src/injectable/decorator.rs
+++ b/crates/oxc_angular_compiler/src/injectable/decorator.rs
@@ -218,7 +218,7 @@ pub fn extract_injectable_metadata<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
 ) -> Option<InjectableMetadata<'a>> {
-    let class_name = class.id.as_ref()?.name.clone();
+    let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
     let class_span = class.span;
 
     // Find the @Injectable decorator
@@ -293,7 +293,7 @@ fn is_injectable_decorator(decorator: &Decorator<'_>) -> bool {
 
 fn get_property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.clone()),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.clone().into()),
         PropertyKey::StringLiteral(s) => Some(s.value.clone()),
         _ => None,
     }
@@ -603,11 +603,11 @@ fn extract_param_dependency<'a>(
 fn get_decorator_name<'a>(expr: &'a Expression<'a>) -> Option<Atom<'a>> {
     match expr {
         // @Optional
-        Expression::Identifier(id) => Some(id.name.clone()),
+        Expression::Identifier(id) => Some(id.name.clone().into()),
         // @Optional()
         Expression::CallExpression(call) => {
             if let Expression::Identifier(id) = &call.callee {
-                Some(id.name.clone())
+                Some(id.name.clone().into())
             } else {
                 None
             }
@@ -628,8 +628,8 @@ fn extract_param_token<'a>(
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
         // Get the type name
-        let type_name = match &type_ref.type_name {
-            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone(),
+        let type_name: Atom<'a> = match &type_ref.type_name {
+            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone().into(),
             oxc_ast::ast::TSTypeName::QualifiedName(_)
             | oxc_ast::ast::TSTypeName::ThisExpression(_) => {
                 // Qualified names like Namespace.Type or 'this' type - not valid injection tokens

--- a/crates/oxc_angular_compiler/src/ng_module/decorator.rs
+++ b/crates/oxc_angular_compiler/src/ng_module/decorator.rs
@@ -182,7 +182,7 @@ pub fn extract_ng_module_metadata<'a>(
     class: &'a Class<'a>,
 ) -> Option<NgModuleMetadata<'a>> {
     // Get the class name
-    let class_name = class.id.as_ref()?.name.clone();
+    let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
     let class_span = class.span;
 
     // Find the @NgModule decorator
@@ -307,7 +307,7 @@ fn is_ng_module_call(callee: &Expression<'_>) -> bool {
 /// Get the name of a property key as a string.
 fn get_property_key_name<'a>(key: &PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.clone()),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.clone().into()),
         PropertyKey::StringLiteral(lit) => Some(lit.value.clone()),
         _ => None,
     }
@@ -341,7 +341,7 @@ fn extract_reference_array<'a>(
         match element {
             // Simple identifier: [SomeComponent]
             ArrayExpressionElement::Identifier(id) => {
-                result.push(id.name.clone());
+                result.push(id.name.clone().into());
             }
             // Forward reference: forwardRef(() => SomeComponent)
             // Or method call: StoreModule.forRoot(...), EffectsModule.forRoot([...])
@@ -353,7 +353,7 @@ fn extract_reference_array<'a>(
                             call.arguments.first()
                         {
                             if let Some(Expression::Identifier(inner_id)) = arrow.get_expression() {
-                                result.push(inner_id.name.clone());
+                                result.push(inner_id.name.clone().into());
                             }
                         }
                     }
@@ -361,7 +361,7 @@ fn extract_reference_array<'a>(
                     // Module.forRoot(...) or Module.forChild(...) pattern
                     // Extract the base class identifier for ɵmod scope resolution
                     if let Expression::Identifier(id) = &member.object {
-                        result.push(id.name.clone());
+                        result.push(id.name.clone().into());
                     }
                 }
             }
@@ -386,7 +386,7 @@ fn extract_identifier_array<'a>(
 
     for element in &arr.elements {
         if let ArrayExpressionElement::Identifier(id) = element {
-            result.push(id.name.clone());
+            result.push(id.name.clone().into());
         }
     }
 
@@ -494,11 +494,11 @@ fn extract_param_dependency<'a>(
 fn get_decorator_name<'a>(expr: &'a Expression<'a>) -> Option<Atom<'a>> {
     match expr {
         // @Optional
-        Expression::Identifier(id) => Some(id.name.clone()),
+        Expression::Identifier(id) => Some(id.name.clone().into()),
         // @Optional()
         Expression::CallExpression(call) => {
             if let Expression::Identifier(id) = &call.callee {
-                Some(id.name.clone())
+                Some(id.name.clone().into())
             } else {
                 None
             }
@@ -519,8 +519,8 @@ fn extract_param_token<'a>(
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
         // Get the type name
-        let type_name = match &type_ref.type_name {
-            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone(),
+        let type_name: Atom<'a> = match &type_ref.type_name {
+            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone().into(),
             oxc_ast::ast::TSTypeName::QualifiedName(_)
             | oxc_ast::ast::TSTypeName::ThisExpression(_) => {
                 // Qualified names like Namespace.Type or 'this' type - not valid injection tokens

--- a/crates/oxc_angular_compiler/src/output/oxc_converter.rs
+++ b/crates/oxc_angular_compiler/src/output/oxc_converter.rs
@@ -70,7 +70,7 @@ pub fn convert_oxc_expression<'a>(
 
         // Identifiers
         Expression::Identifier(id) => Some(OutputExpression::ReadVar(Box::new_in(
-            ReadVarExpr { name: id.name.clone(), source_span: None },
+            ReadVarExpr { name: id.name.clone().into(), source_span: None },
             allocator,
         ))),
 
@@ -97,7 +97,7 @@ pub fn convert_oxc_expression<'a>(
             Some(OutputExpression::ReadProp(Box::new_in(
                 ReadPropExpr {
                     receiver: Box::new_in(receiver, allocator),
-                    name: member.property.name.clone(),
+                    name: member.property.name.clone().into(),
                     optional: member.optional,
                     source_span: None,
                 },
@@ -287,7 +287,7 @@ fn convert_object_expression<'a>(
             ObjectPropertyKind::ObjectProperty(p) => {
                 // Get the property key
                 let (key, quoted) = match &p.key {
-                    PropertyKey::StaticIdentifier(id) => (id.name.clone(), false),
+                    PropertyKey::StaticIdentifier(id) => (id.name.clone().into(), false),
                     PropertyKey::StringLiteral(lit) => (lit.value.clone(), true),
                     PropertyKey::NumericLiteral(lit) => {
                         (Atom::from(allocator.alloc_str(&lit.value.to_string())), true)
@@ -405,7 +405,7 @@ fn convert_arrow_function_expression<'a>(
     for param in &arrow.params.items {
         // For simplicity, only handle identifier patterns
         if let BindingPattern::BindingIdentifier(id) = &param.pattern {
-            params.push(FnParam { name: id.name.clone() });
+            params.push(FnParam { name: id.name.clone().into() });
         } else {
             // Complex patterns not supported
             return None;
@@ -584,7 +584,7 @@ fn convert_chain_element<'a>(
             Some(OutputExpression::ReadProp(Box::new_in(
                 ReadPropExpr {
                     receiver: Box::new_in(receiver, allocator),
-                    name: member.property.name.clone(),
+                    name: member.property.name.clone().into(),
                     optional: member.optional,
                     source_span: None,
                 },

--- a/crates/oxc_angular_compiler/src/pipe/decorator.rs
+++ b/crates/oxc_angular_compiler/src/pipe/decorator.rs
@@ -109,7 +109,7 @@ pub fn extract_pipe_metadata<'a>(
     implicit_standalone: bool,
 ) -> Option<PipeMetadata<'a>> {
     // Get the class name
-    let class_name = class.id.as_ref()?.name.clone();
+    let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
     let class_span = class.span;
 
     // Find the @Pipe decorator
@@ -202,7 +202,7 @@ fn is_pipe_call(callee: &Expression<'_>) -> bool {
 /// Get the name of a property key as a string.
 fn get_property_key_name<'a>(key: &PropertyKey<'a>) -> Option<Atom<'a>> {
     match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.clone()),
+        PropertyKey::StaticIdentifier(id) => Some(id.name.clone().into()),
         PropertyKey::StringLiteral(lit) => Some(lit.value.clone()),
         _ => None,
     }
@@ -317,11 +317,11 @@ fn extract_param_dependency<'a>(
 fn get_decorator_name<'a>(expr: &'a Expression<'a>) -> Option<Atom<'a>> {
     match expr {
         // @Optional
-        Expression::Identifier(id) => Some(id.name.clone()),
+        Expression::Identifier(id) => Some(id.name.clone().into()),
         // @Optional()
         Expression::CallExpression(call) => {
             if let Expression::Identifier(id) = &call.callee {
-                Some(id.name.clone())
+                Some(id.name.clone().into())
             } else {
                 None
             }
@@ -342,8 +342,8 @@ fn extract_param_token<'a>(
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
         // Get the type name
-        let type_name = match &type_ref.type_name {
-            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone(),
+        let type_name: Atom<'a> = match &type_ref.type_name {
+            oxc_ast::ast::TSTypeName::IdentifierReference(id) => id.name.clone().into(),
             oxc_ast::ast::TSTypeName::QualifiedName(_)
             | oxc_ast::ast::TSTypeName::ThisExpression(_) => {
                 // Qualified names like Namespace.Type or 'this' type - not valid injection tokens

--- a/napi/angular-compiler/src/lib.rs
+++ b/napi/angular-compiler/src/lib.rs
@@ -2346,7 +2346,7 @@ pub fn extract_angular_component_by_ast(
                     if let AssignmentTarget::StaticMemberExpression(member) = &assign.left {
                         // Check if the object is the class name
                         let is_target_class = match &member.object {
-                            Expression::Identifier(id) => id.name == class_name,
+                            Expression::Identifier(id) => id.name.as_str() == class_name,
                             _ => false,
                         };
 
@@ -2373,7 +2373,8 @@ pub fn extract_angular_component_by_ast(
             // Handle class declarations for static properties
             Statement::ClassDeclaration(class) => {
                 // Check if this is the target class
-                let is_target_class = class.id.as_ref().is_some_and(|id| id.name == class_name);
+                let is_target_class =
+                    class.id.as_ref().is_some_and(|id| id.name.as_str() == class_name);
 
                 if is_target_class {
                     for element in &class.body.body {
@@ -2417,7 +2418,8 @@ pub fn extract_angular_component_by_ast(
                 if let Some(oxc_ast::ast::Declaration::ClassDeclaration(class)) =
                     &export.declaration
                 {
-                    let is_target_class = class.id.as_ref().is_some_and(|id| id.name == class_name);
+                    let is_target_class =
+                        class.id.as_ref().is_some_and(|id| id.name.as_str() == class_name);
 
                     if is_target_class {
                         for element in &class.body.body {


### PR DESCRIPTION
Adapt to breaking change where IdentifierReference.name, BindingIdentifier.name,
and IdentifierName.name changed from Atom<'a> to Ident<'a>. Added .into() conversions
and .as_str() for string comparisons throughout the codebase.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core `oxc_*` parsing/semantic dependencies and touches many identifier-handling call sites; risk is mainly compatibility/regression in metadata extraction and import-elision behavior due to API/type changes.
> 
> **Overview**
> Updates workspace `oxc_*` dependencies from `0.110` to `0.116` (plus corresponding `Cargo.lock` refresh with new/updated transitive crates).
> 
> Adapts compiler code to upstream breaking changes where identifier `name` fields are no longer `Atom` by adding `.into()` conversions, switching string comparisons to `name.as_str()`, and tightening APIs like `ImportElisionAnalyzer::should_elide` to accept `&str` to match the new identifier types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 270961378da4f0b9c07b463afc4a728c18d68ebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->