### PR TITLE
feat(vite): add templateTransform hook for template preprocessing

### DIFF
--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -82,6 +82,9 @@ export interface PluginOptions {
    * ```
    */
   angularVersion?: AngularVersion
+
+  /** Optional callback to transform template content before compilation. Applied during both initial build and HMR. */
+  templateTransform?: (content: string, filePath: string) => string
 }
 
 // Match all TypeScript files - we'll filter by @Component/@Directive decorator in the handler
@@ -160,6 +163,9 @@ export function angular(options: PluginOptions = {}): Plugin[] {
       if (!content) {
         try {
           content = await readFile(templatePath, 'utf-8')
+          if (options.templateTransform) {
+            content = options.templateTransform(content, templatePath)
+          }
           resourceCache.set(templatePath, content)
         } catch {
           console.warn(`Failed to read template: ${templatePath}`)
@@ -368,6 +374,9 @@ export function angular(options: PluginOptions = {}): Plugin[] {
               if (templateUrls.length > 0) {
                 const templatePath = resolve(dir, templateUrls[0])
                 templateContent = await readFile(templatePath, 'utf-8')
+                if (options.templateTransform) {
+                  templateContent = options.templateTransform(templateContent, templatePath)
+                }
               } else {
                 templateContent = extractInlineTemplate(source)
               }


### PR DESCRIPTION
## Summary

- Adds an optional `templateTransform` callback to `PluginOptions` that transforms template content after reading from disk but before compilation
- Applied in both `resolveResources()` (initial build) and the HMR recompilation endpoint, so behavior stays consistent
- Non-breaking: the callback is optional and defaults to no-op

Closes #149

## Usage

```ts
angular({
  templateTransform: (content, filePath) => {
    // Add data-testid attributes, inject source location metadata, etc.
    return transformedContent
  },
})
```

## Test plan

- [ ] Verify external templates are transformed during initial compilation
- [ ] Verify HMR updates apply the same transform to fresh template content
- [ ] Verify behavior is unchanged when `templateTransform` is not provided

Happy to add tests if desired — the change is minimal (~6 lines of logic) and the repo doesn't currently have plugin-level unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)