### PR TITLE
feat(compiler): add RawSource fallback for unconvertible expressions

### DIFF
--- a/crates/oxc_angular_compiler/src/class_metadata/builders.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/builders.rs
@@ -23,6 +23,7 @@ use crate::output::oxc_converter::convert_oxc_expression;
 pub fn build_decorator_metadata_array<'a>(
     allocator: &'a Allocator,
     decorators: &[&Decorator<'a>],
+    source: &'a str,
 ) -> OutputExpression<'a> {
     let mut decorator_entries = AllocVec::new_in(allocator);
 
@@ -38,7 +39,7 @@ pub fn build_decorator_metadata_array<'a>(
                 ))),
                 Expression::StaticMemberExpression(member) => {
                     // Handle namespaced decorators like ng.Component
-                    convert_oxc_expression(allocator, &member.object).map(|receiver| {
+                    convert_oxc_expression(allocator, &member.object, source).map(|receiver| {
                         OutputExpression::ReadProp(Box::new_in(
                             ReadPropExpr {
                                 receiver: Box::new_in(receiver, allocator),
@@ -77,7 +78,7 @@ pub fn build_decorator_metadata_array<'a>(
             let mut args = AllocVec::new_in(allocator);
             for arg in &call.arguments {
                 let expr = arg.to_expression();
-                if let Some(converted) = convert_oxc_expression(allocator, expr) {
+                if let Some(converted) = convert_oxc_expression(allocator, expr, source) {
                     args.push(converted);
                 }
             }
@@ -122,6 +123,7 @@ pub fn build_ctor_params_metadata<'a>(
     constructor_deps: Option<&[R3DependencyMetadata<'a>]>,
     namespace_registry: &mut NamespaceRegistry<'a>,
     import_map: &ImportMap<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     // Find constructor
     let constructor = class.body.body.iter().find_map(|element| {
@@ -163,7 +165,7 @@ pub fn build_ctor_params_metadata<'a>(
         // Extract decorators from the parameter
         let param_decorators = extract_angular_decorators_from_param(param);
         if !param_decorators.is_empty() {
-            let decorators_array = build_decorator_metadata_array(allocator, &param_decorators);
+            let decorators_array = build_decorator_metadata_array(allocator, &param_decorators, source);
             map_entries.push(LiteralMapEntry {
                 key: Atom::from("decorators"),
                 value: decorators_array,
@@ -205,6 +207,7 @@ pub fn build_ctor_params_metadata<'a>(
 pub fn build_prop_decorators_metadata<'a>(
     allocator: &'a Allocator,
     class: &Class<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     const ANGULAR_PROP_DECORATORS: &[&str] = &[
         "Input",
@@ -251,7 +254,7 @@ pub fn build_prop_decorators_metadata<'a>(
         }
 
         // Build decorators array for this property
-        let decorators_array = build_decorator_metadata_array(allocator, &angular_decorators);
+        let decorators_array = build_decorator_metadata_array(allocator, &angular_decorators, source);
 
         prop_entries.push(LiteralMapEntry {
             key: prop_name,

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -50,6 +50,7 @@ pub fn extract_component_metadata<'a>(
     class: &'a Class<'a>,
     implicit_standalone: bool,
     import_map: &ImportMap<'a>,
+    source: &'a str,
 ) -> Option<ComponentMetadata<'a>> {
     // Get the class name
     let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
@@ -130,7 +131,7 @@ pub fn extract_component_metadata<'a>(
                     // 1. The identifier list for local analysis
                     metadata.imports = extract_identifier_array(allocator, &prop.value);
                     // 2. The raw expression to pass to ɵɵgetComponentDepsFactory in RuntimeResolved mode
-                    metadata.raw_imports = convert_oxc_expression(allocator, &prop.value);
+                    metadata.raw_imports = convert_oxc_expression(allocator, &prop.value, source);
                 }
                 "exportAs" => {
                     // exportAs can be comma-separated: "foo, bar"
@@ -150,7 +151,7 @@ pub fn extract_component_metadata<'a>(
                 "animations" => {
                     // Extract animations expression as full OutputExpression
                     // Handles both identifier references and complex array expressions
-                    metadata.animations = convert_oxc_expression(allocator, &prop.value);
+                    metadata.animations = convert_oxc_expression(allocator, &prop.value, source);
                 }
                 "schemas" => {
                     // Extract schemas identifiers (e.g., [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA])
@@ -159,11 +160,11 @@ pub fn extract_component_metadata<'a>(
                 "providers" => {
                     // Extract providers as full OutputExpression
                     // Handles complex expressions like [{provide: TOKEN, useFactory: Factory}]
-                    metadata.providers = convert_oxc_expression(allocator, &prop.value);
+                    metadata.providers = convert_oxc_expression(allocator, &prop.value, source);
                 }
                 "viewProviders" => {
                     // Extract view providers as full OutputExpression
-                    metadata.view_providers = convert_oxc_expression(allocator, &prop.value);
+                    metadata.view_providers = convert_oxc_expression(allocator, &prop.value, source);
                 }
                 "hostDirectives" => {
                     // Extract host directives array
@@ -235,7 +236,7 @@ pub fn extract_component_metadata<'a>(
         extract_constructor_deps(allocator, class, import_map, has_superclass);
 
     // Extract inputs from @Input decorators on class members
-    metadata.inputs = extract_input_metadata(allocator, class);
+    metadata.inputs = extract_input_metadata(allocator, class, source);
 
     // Extract outputs from @Output decorators on class members
     metadata.outputs = extract_output_metadata(allocator, class);
@@ -1130,7 +1131,7 @@ mod tests {
 
             if let Some(class) = class {
                 if let Some(metadata) =
-                    extract_component_metadata(&allocator, class, implicit_standalone, &import_map)
+                    extract_component_metadata(&allocator, class, implicit_standalone, &import_map, code)
                 {
                     found_metadata = Some(metadata);
                     break;

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -1559,7 +1559,7 @@ pub fn transform_angular_file(
             let implicit_standalone = options.implicit_standalone();
 
             if let Some(mut metadata) =
-                extract_component_metadata(allocator, class, implicit_standalone, &import_map)
+                extract_component_metadata(allocator, class, implicit_standalone, &import_map, source)
             {
                 // 3. Resolve external styles and merge into metadata
                 resolve_styles(allocator, &mut metadata, resolved_resources);
@@ -1574,11 +1574,11 @@ pub fn transform_angular_file(
                     let template = allocator.alloc_str(&template_string);
                     // 4.5 Extract view queries from the class (for @ViewChild/@ViewChildren)
                     // These need to be passed to compile_component_full so predicates can be pooled
-                    let view_queries = extract_view_queries(allocator, class);
+                    let view_queries = extract_view_queries(allocator, class, source);
 
                     // 4.6 Extract content queries from the class (for @ContentChild/@ContentChildren)
                     // Signal-based queries (contentChild(), contentChildren()) are also detected here
-                    let content_queries = extract_content_queries(allocator, class);
+                    let content_queries = extract_content_queries(allocator, class, source);
 
                     // Collect content query property names for .d.ts generation
                     // (before content_queries is moved into compile_component_full)
@@ -1637,7 +1637,7 @@ pub fn transform_angular_file(
 
                             // Check if the class also has an @Injectable decorator.
                             // @Injectable is SHARED precedence and can coexist with @Component.
-                            let has_injectable = extract_injectable_metadata(allocator, class);
+                            let has_injectable = extract_injectable_metadata(allocator, class, source);
                             if let Some(injectable_metadata) = &has_injectable {
                                 if let Some(span) = find_injectable_decorator_span(class) {
                                     decorator_spans_to_remove.push(span);
@@ -1699,6 +1699,7 @@ pub fn transform_angular_file(
                                         decorators: build_decorator_metadata_array(
                                             allocator,
                                             &[decorator],
+                                            source,
                                         ),
                                         ctor_parameters: build_ctor_params_metadata(
                                             allocator,
@@ -1706,9 +1707,10 @@ pub fn transform_angular_file(
                                             ctor_deps_slice,
                                             &mut file_namespace_registry,
                                             &import_map,
+                                            source,
                                         ),
                                         prop_decorators: build_prop_decorators_metadata(
-                                            allocator, class,
+                                            allocator, class, source,
                                         ),
                                     };
 
@@ -1789,7 +1791,7 @@ pub fn transform_angular_file(
                 // the directive and creating conflicting property definitions (like
                 // ɵfac getters) that interfere with the AOT-compiled assignments.
                 if let Some(mut directive_metadata) =
-                    extract_directive_metadata(allocator, class, implicit_standalone)
+                    extract_directive_metadata(allocator, class, implicit_standalone, source)
                 {
                     // Track decorator span for removal
                     if let Some(span) = find_directive_decorator_span(class) {
@@ -1847,7 +1849,7 @@ pub fn transform_angular_file(
 
                     // Check if the class also has an @Injectable decorator.
                     // @Injectable is SHARED precedence and can coexist with @Directive.
-                    let has_injectable = extract_injectable_metadata(allocator, class);
+                    let has_injectable = extract_injectable_metadata(allocator, class, source);
                     if let Some(injectable_metadata) = &has_injectable {
                         if let Some(span) = find_injectable_decorator_span(class) {
                             decorator_spans_to_remove.push(span);
@@ -1921,7 +1923,7 @@ pub fn transform_angular_file(
 
                         // Check if the class also has an @Injectable decorator (issue #65).
                         // @Injectable is SHARED precedence and can coexist with @Pipe.
-                        let has_injectable = extract_injectable_metadata(allocator, class);
+                        let has_injectable = extract_injectable_metadata(allocator, class, source);
                         if let Some(injectable_metadata) = &has_injectable {
                             if let Some(span) = find_injectable_decorator_span(class) {
                                 decorator_spans_to_remove.push(span);
@@ -1958,7 +1960,7 @@ pub fn transform_angular_file(
                         );
                     }
                 } else if let Some(mut ng_module_metadata) =
-                    extract_ng_module_metadata(allocator, class)
+                    extract_ng_module_metadata(allocator, class, source)
                 {
                     // Not a @Component, @Directive, @Injectable, or @Pipe - check if it's an @NgModule
                     // We need to compile @NgModule classes to generate ɵmod, ɵfac, and ɵinj definitions.
@@ -2002,7 +2004,7 @@ pub fn transform_angular_file(
 
                         // Check if the class also has an @Injectable decorator.
                         // @Injectable is SHARED precedence and can coexist with @NgModule.
-                        let has_injectable = extract_injectable_metadata(allocator, class);
+                        let has_injectable = extract_injectable_metadata(allocator, class, source);
                         if let Some(injectable_metadata) = &has_injectable {
                             if let Some(span) = find_injectable_decorator_span(class) {
                                 decorator_spans_to_remove.push(span);
@@ -2049,7 +2051,7 @@ pub fn transform_angular_file(
                         );
                     }
                 } else if let Some(mut injectable_metadata) =
-                    extract_injectable_metadata(allocator, class)
+                    extract_injectable_metadata(allocator, class, source)
                 {
                     // Standalone @Injectable (no PRIMARY decorator on the class)
                     // We need to compile @Injectable classes to generate ɵprov and ɵfac definitions.

--- a/crates/oxc_angular_compiler/src/directive/decorator.rs
+++ b/crates/oxc_angular_compiler/src/directive/decorator.rs
@@ -77,6 +77,7 @@ pub fn extract_directive_metadata<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
     implicit_standalone: bool,
+    source: &'a str,
 ) -> Option<R3DirectiveMetadata<'a>> {
     // Get the class name
     let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
@@ -142,7 +143,7 @@ pub fn extract_directive_metadata<'a>(
                         }
                     }
                     "providers" => {
-                        if let Some(providers) = convert_oxc_expression(allocator, &prop.value) {
+                        if let Some(providers) = convert_oxc_expression(allocator, &prop.value, source) {
                             builder = builder.providers(providers);
                         }
                     }
@@ -164,7 +165,7 @@ pub fn extract_directive_metadata<'a>(
     }
 
     // Extract @Input/@Output/@HostBinding/@HostListener from class members
-    builder = builder.extract_from_class(allocator, class);
+    builder = builder.extract_from_class(allocator, class, source);
 
     // Detect if ngOnChanges lifecycle hook is implemented
     // Similar to Angular's: const usesOnChanges = members.some(member => ...)
@@ -180,7 +181,7 @@ pub fn extract_directive_metadata<'a>(
     // Extract constructor dependencies for factory generation
     // This enables proper DI for directive constructors
     // See: packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
-    let constructor_deps = extract_constructor_deps(allocator, class, has_superclass);
+    let constructor_deps = extract_constructor_deps(allocator, class, has_superclass, source);
     if let Some(deps) = constructor_deps {
         builder = builder.deps(deps);
     }
@@ -252,6 +253,7 @@ fn extract_constructor_deps<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
     has_superclass: bool,
+    source: &'a str,
 ) -> Option<Vec<'a, R3DependencyMetadata<'a>>> {
     // Find the constructor method
     let constructor = class.body.body.iter().find_map(|element| {
@@ -270,7 +272,7 @@ fn extract_constructor_deps<'a>(
             let mut deps = Vec::with_capacity_in(params.items.len(), allocator);
 
             for param in &params.items {
-                let dep = extract_param_dependency(allocator, param);
+                let dep = extract_param_dependency(allocator, param, source);
                 deps.push(dep);
             }
 
@@ -290,6 +292,7 @@ fn extract_constructor_deps<'a>(
 fn extract_param_dependency<'a>(
     allocator: &'a Allocator,
     param: &oxc_ast::ast::FormalParameter<'a>,
+    source: &'a str,
 ) -> R3DependencyMetadata<'a> {
     // Extract flags and @Inject token from decorators
     let mut optional = false;
@@ -306,7 +309,7 @@ fn extract_param_dependency<'a>(
                     // @Inject(TOKEN) - extract the token
                     if let Expression::CallExpression(call) = &decorator.expression {
                         if let Some(arg) = call.arguments.first() {
-                            inject_token = convert_oxc_expression(allocator, arg.to_expression());
+                            inject_token = convert_oxc_expression(allocator, arg.to_expression(), source);
                         }
                     }
                 }
@@ -881,7 +884,7 @@ mod tests {
 
             if let Some(class) = class {
                 if let Some(metadata) =
-                    extract_directive_metadata(&allocator, class, implicit_standalone)
+                    extract_directive_metadata(&allocator, class, implicit_standalone, code)
                 {
                     found_metadata = Some(metadata);
                     break;

--- a/crates/oxc_angular_compiler/src/directive/metadata.rs
+++ b/crates/oxc_angular_compiler/src/directive/metadata.rs
@@ -410,9 +410,9 @@ impl<'a> R3DirectiveMetadataBuilder<'a> {
     ///
     /// # Returns
     /// The builder with all extracted metadata added.
-    pub fn extract_from_class(mut self, allocator: &'a Allocator, class: &'a Class<'a>) -> Self {
+    pub fn extract_from_class(mut self, allocator: &'a Allocator, class: &'a Class<'a>, source: &'a str) -> Self {
         // Extract inputs from @Input decorators
-        let inputs = super::property_decorators::extract_input_metadata(allocator, class);
+        let inputs = super::property_decorators::extract_input_metadata(allocator, class, source);
         for input in inputs {
             self = self.add_input(input);
         }
@@ -424,13 +424,13 @@ impl<'a> R3DirectiveMetadataBuilder<'a> {
         }
 
         // Extract view queries from @ViewChild/@ViewChildren
-        let view_queries = super::property_decorators::extract_view_queries(allocator, class);
+        let view_queries = super::property_decorators::extract_view_queries(allocator, class, source);
         for query in view_queries {
             self = self.add_view_query(query);
         }
 
         // Extract content queries from @ContentChild/@ContentChildren
-        let content_queries = super::property_decorators::extract_content_queries(allocator, class);
+        let content_queries = super::property_decorators::extract_content_queries(allocator, class, source);
         for query in content_queries {
             self = self.add_query(query);
         }
@@ -595,7 +595,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestDirective"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestDirective")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -633,7 +633,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestDirective"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestDirective")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -666,7 +666,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestComponent"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestComponent")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -699,7 +699,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestComponent"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestComponent")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -732,7 +732,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestDirective"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestDirective")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -767,7 +767,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestDirective"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestDirective")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -805,7 +805,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("TestComponent"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestComponent")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -835,7 +835,7 @@ mod tests {
         let builder = R3DirectiveMetadataBuilder::new(&allocator)
             .name(Atom::from("EmptyDirective"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("EmptyDirective")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());
@@ -868,7 +868,7 @@ mod tests {
             .name(Atom::from("TestDirective"))
             .r#type(OutputAstBuilder::variable(&allocator, Atom::from("TestDirective")))
             .add_input(R3InputMetadata::simple(Atom::from("existingInput")))
-            .extract_from_class(&allocator, class.unwrap());
+            .extract_from_class(&allocator, class.unwrap(), code);
 
         let metadata = builder.build();
         assert!(metadata.is_some());

--- a/crates/oxc_angular_compiler/src/directive/property_decorators.rs
+++ b/crates/oxc_angular_compiler/src/directive/property_decorators.rs
@@ -150,6 +150,7 @@ impl<'a> Default for InputConfig<'a> {
 fn parse_input_config<'a>(
     allocator: &'a Allocator,
     decorator: &'a Decorator<'a>,
+    source: &'a str,
 ) -> InputConfig<'a> {
     let Expression::CallExpression(call) = &decorator.expression else {
         return InputConfig::default();
@@ -183,7 +184,7 @@ fn parse_input_config<'a>(
                             config.required = extract_boolean_value(&prop.value).unwrap_or(false);
                         }
                         "transform" => {
-                            config.transform = convert_oxc_expression(allocator, &prop.value);
+                            config.transform = convert_oxc_expression(allocator, &prop.value, source);
                         }
                         _ => {}
                     }
@@ -484,6 +485,7 @@ fn try_parse_signal_input<'a>(
 pub fn extract_input_metadata<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
+    source: &'a str,
 ) -> Vec<'a, R3InputMetadata<'a>> {
     let mut inputs = Vec::new_in(allocator);
 
@@ -496,7 +498,7 @@ pub fn extract_input_metadata<'a>(
                         continue;
                     };
 
-                    let config = parse_input_config(allocator, decorator);
+                    let config = parse_input_config(allocator, decorator, source);
 
                     let binding_property_name =
                         config.alias.unwrap_or_else(|| class_property_name.clone());
@@ -537,7 +539,7 @@ pub fn extract_input_metadata<'a>(
                     continue;
                 };
 
-                let config = parse_input_config(allocator, decorator);
+                let config = parse_input_config(allocator, decorator, source);
 
                 let binding_property_name =
                     config.alias.unwrap_or_else(|| class_property_name.clone());
@@ -561,7 +563,7 @@ pub fn extract_input_metadata<'a>(
                     continue;
                 };
 
-                let config = parse_input_config(allocator, decorator);
+                let config = parse_input_config(allocator, decorator, source);
 
                 let binding_property_name =
                     config.alias.unwrap_or_else(|| class_property_name.clone());
@@ -754,6 +756,7 @@ fn parse_query_config<'a>(
     allocator: &'a Allocator,
     decorator: &'a Decorator<'a>,
     decorator_name: &str,
+    source: &'a str,
 ) -> QueryConfig<'a> {
     let Expression::CallExpression(call) = &decorator.expression else {
         return QueryConfig::default_for(decorator_name);
@@ -779,7 +782,7 @@ fn parse_query_config<'a>(
             let expr = first_arg.to_expression();
             // Unwrap forwardRef if present - Angular doesn't include forwardRef in compiled output
             let unwrapped_expr = try_unwrap_forward_ref(expr).unwrap_or(expr);
-            if let Some(output_expr) = convert_oxc_expression(allocator, unwrapped_expr) {
+            if let Some(output_expr) = convert_oxc_expression(allocator, unwrapped_expr, source) {
                 config.predicate = Some(QueryPredicate::Type(output_expr));
             }
         }
@@ -799,7 +802,7 @@ fn parse_query_config<'a>(
                             config.is_static = extract_boolean_value(&prop.value).unwrap_or(false);
                         }
                         "read" => {
-                            config.read = convert_oxc_expression(allocator, &prop.value);
+                            config.read = convert_oxc_expression(allocator, &prop.value, source);
                         }
                         "descendants" => {
                             // Use the decorator-specific default if not explicitly set
@@ -866,6 +869,7 @@ fn try_parse_signal_query<'a>(
     allocator: &'a Allocator,
     value: &'a Expression<'a>,
     property_name: Atom<'a>,
+    source: &'a str,
 ) -> Option<(SignalQueryType, R3QueryMetadata<'a>)> {
     // Check if the value is a call expression
     let call_expr = match value {
@@ -941,7 +945,7 @@ fn try_parse_signal_query<'a>(
             let expr = predicate_arg.to_expression();
             // Unwrap forwardRef if present - Angular doesn't include forwardRef in compiled output
             let unwrapped_expr = try_unwrap_forward_ref(expr).unwrap_or(expr);
-            let output_expr = convert_oxc_expression(allocator, unwrapped_expr)?;
+            let output_expr = convert_oxc_expression(allocator, unwrapped_expr, source)?;
             QueryPredicate::Type(output_expr)
         }
     };
@@ -960,7 +964,7 @@ fn try_parse_signal_query<'a>(
 
                     match key_name.as_str() {
                         "read" => {
-                            read = convert_oxc_expression(allocator, &prop.value);
+                            read = convert_oxc_expression(allocator, &prop.value, source);
                         }
                         "descendants" => {
                             descendants = extract_boolean_value(&prop.value).unwrap_or(descendants);
@@ -1007,6 +1011,7 @@ fn try_parse_signal_query<'a>(
 pub fn extract_view_queries<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
+    source: &'a str,
 ) -> Vec<'a, R3QueryMetadata<'a>> {
     // Use separate vectors to match Angular's ordering approach.
     // Angular groups queries by type, maintaining declaration order within each group:
@@ -1026,7 +1031,7 @@ pub fn extract_view_queries<'a>(
                 if let Some(value) = &prop.value {
                     if let Some(property_name) = get_property_key_name(&prop.key) {
                         if let Some((query_type, metadata)) =
-                            try_parse_signal_query(allocator, value, property_name)
+                            try_parse_signal_query(allocator, value, property_name, source)
                         {
                             if query_type.is_view_query() {
                                 signal_queries.push(metadata);
@@ -1039,7 +1044,7 @@ pub fn extract_view_queries<'a>(
                 // Check for decorator-based queries (@ViewChild, @ViewChildren)
                 if let Some(decorator) = find_decorator_by_name(&prop.decorators, "ViewChild") {
                     if let Some(property_name) = get_property_key_name(&prop.key) {
-                        let config = parse_query_config(allocator, decorator, "ViewChild");
+                        let config = parse_query_config(allocator, decorator, "ViewChild", source);
                         if let Some(predicate) = config.predicate {
                             view_child_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1057,7 +1062,7 @@ pub fn extract_view_queries<'a>(
                     find_decorator_by_name(&prop.decorators, "ViewChildren")
                 {
                     if let Some(property_name) = get_property_key_name(&prop.key) {
-                        let config = parse_query_config(allocator, decorator, "ViewChildren");
+                        let config = parse_query_config(allocator, decorator, "ViewChildren", source);
                         if let Some(predicate) = config.predicate {
                             view_children_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1079,7 +1084,7 @@ pub fn extract_view_queries<'a>(
                 // Check for decorator-based queries on setters/getters
                 if let Some(decorator) = find_decorator_by_name(&method.decorators, "ViewChild") {
                     if let Some(property_name) = get_property_key_name(&method.key) {
-                        let config = parse_query_config(allocator, decorator, "ViewChild");
+                        let config = parse_query_config(allocator, decorator, "ViewChild", source);
                         if let Some(predicate) = config.predicate {
                             view_child_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1097,7 +1102,7 @@ pub fn extract_view_queries<'a>(
                     find_decorator_by_name(&method.decorators, "ViewChildren")
                 {
                     if let Some(property_name) = get_property_key_name(&method.key) {
-                        let config = parse_query_config(allocator, decorator, "ViewChildren");
+                        let config = parse_query_config(allocator, decorator, "ViewChildren", source);
                         if let Some(predicate) = config.predicate {
                             view_children_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1145,6 +1150,7 @@ pub fn extract_view_queries<'a>(
 pub fn extract_content_queries<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
+    source: &'a str,
 ) -> Vec<'a, R3QueryMetadata<'a>> {
     // Use separate vectors to match Angular's ordering approach.
     // Angular groups queries by type, maintaining declaration order within each group:
@@ -1164,7 +1170,7 @@ pub fn extract_content_queries<'a>(
                 if let Some(value) = &prop.value {
                     if let Some(property_name) = get_property_key_name(&prop.key) {
                         if let Some((query_type, metadata)) =
-                            try_parse_signal_query(allocator, value, property_name)
+                            try_parse_signal_query(allocator, value, property_name, source)
                         {
                             if !query_type.is_view_query() {
                                 signal_queries.push(metadata);
@@ -1177,7 +1183,7 @@ pub fn extract_content_queries<'a>(
                 // Check for decorator-based queries (@ContentChild, @ContentChildren)
                 if let Some(decorator) = find_decorator_by_name(&prop.decorators, "ContentChild") {
                     if let Some(property_name) = get_property_key_name(&prop.key) {
-                        let config = parse_query_config(allocator, decorator, "ContentChild");
+                        let config = parse_query_config(allocator, decorator, "ContentChild", source);
                         if let Some(predicate) = config.predicate {
                             content_child_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1195,7 +1201,7 @@ pub fn extract_content_queries<'a>(
                     find_decorator_by_name(&prop.decorators, "ContentChildren")
                 {
                     if let Some(property_name) = get_property_key_name(&prop.key) {
-                        let config = parse_query_config(allocator, decorator, "ContentChildren");
+                        let config = parse_query_config(allocator, decorator, "ContentChildren", source);
                         if let Some(predicate) = config.predicate {
                             content_children_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1218,7 +1224,7 @@ pub fn extract_content_queries<'a>(
                 if let Some(decorator) = find_decorator_by_name(&method.decorators, "ContentChild")
                 {
                     if let Some(property_name) = get_property_key_name(&method.key) {
-                        let config = parse_query_config(allocator, decorator, "ContentChild");
+                        let config = parse_query_config(allocator, decorator, "ContentChild", source);
                         if let Some(predicate) = config.predicate {
                             content_child_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1236,7 +1242,7 @@ pub fn extract_content_queries<'a>(
                     find_decorator_by_name(&method.decorators, "ContentChildren")
                 {
                     if let Some(property_name) = get_property_key_name(&method.key) {
-                        let config = parse_query_config(allocator, decorator, "ContentChildren");
+                        let config = parse_query_config(allocator, decorator, "ContentChildren", source);
                         if let Some(predicate) = config.predicate {
                             content_children_queries.push(R3QueryMetadata {
                                 property_name,
@@ -1493,7 +1499,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "value");
@@ -1514,7 +1520,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "inputAlias");
@@ -1532,7 +1538,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "myAlias");
@@ -1551,7 +1557,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "value");
@@ -1570,7 +1576,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "disabled");
         assert!(inputs[0].transform_function.is_some());
@@ -1591,7 +1597,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 3);
 
         assert_eq!(inputs[0].class_property_name.as_str(), "name");
@@ -1619,7 +1625,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
     }
@@ -1640,7 +1646,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "formGroup");
         assert_eq!(inputs[0].binding_property_name.as_str(), "formGroup");
@@ -1661,7 +1667,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "count");
         assert_eq!(inputs[0].binding_property_name.as_str(), "count");
@@ -1681,7 +1687,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "name");
         assert_eq!(inputs[0].binding_property_name.as_str(), "name");
@@ -1701,7 +1707,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "myAlias");
@@ -1721,7 +1727,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "requiredAlias");
@@ -1744,7 +1750,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 3);
 
         // Decorator input
@@ -1776,7 +1782,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "realInput");
         assert!(inputs[0].is_signal);
@@ -1799,7 +1805,7 @@ mod tests {
         assert!(class.is_some());
 
         // Check inputs
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "open");
         assert_eq!(inputs[0].binding_property_name.as_str(), "open");
@@ -1826,7 +1832,7 @@ mod tests {
         assert!(class.is_some());
 
         // Check inputs
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "count");
         assert_eq!(inputs[0].binding_property_name.as_str(), "count");
@@ -1853,7 +1859,7 @@ mod tests {
         assert!(class.is_some());
 
         // Check inputs - binding name should be alias
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "myAlias");
@@ -1880,7 +1886,7 @@ mod tests {
         assert!(class.is_some());
 
         // Check inputs
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "value");
         assert_eq!(inputs[0].binding_property_name.as_str(), "requiredAlias");
@@ -1911,7 +1917,7 @@ mod tests {
         assert!(class.is_some());
 
         // Check inputs - should have all 4 inputs
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 4);
 
         // Decorator input
@@ -1957,7 +1963,7 @@ mod tests {
         assert!(class.is_some());
 
         // Only realModel should be detected as input
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].class_property_name.as_str(), "realModel");
         assert!(inputs[0].is_signal);
@@ -2158,7 +2164,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         let outputs = extract_output_metadata(&allocator, class.as_ref().unwrap());
 
         assert_eq!(inputs.len(), 1);
@@ -2178,7 +2184,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         let outputs = extract_output_metadata(&allocator, class.as_ref().unwrap());
 
         assert_eq!(inputs.len(), 0);
@@ -2201,7 +2207,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "child");
         assert!(queries[0].first);
@@ -2223,7 +2229,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "child");
         assert!(queries[0].first);
@@ -2247,7 +2253,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "child");
         assert!(queries[0].first);
@@ -2267,7 +2273,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "items");
         assert!(!queries[0].first); // ViewChildren returns multiple
@@ -2290,7 +2296,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "panel");
         assert!(queries[0].first);
@@ -2310,7 +2316,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "header");
         assert!(queries[0].first);
@@ -2334,7 +2340,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "item");
         assert!(!queries[0].descendants);
@@ -2352,7 +2358,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "tabs");
         assert!(!queries[0].first); // ContentChildren returns multiple
@@ -2373,8 +2379,8 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap());
-        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
+        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
 
         assert_eq!(view_queries.len(), 2);
         assert_eq!(content_queries.len(), 2);
@@ -2647,10 +2653,10 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         let outputs = extract_output_metadata(&allocator, class.as_ref().unwrap());
-        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap());
-        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
+        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         let host_bindings = extract_host_bindings(&allocator, class.as_ref().unwrap());
         let host_listeners = extract_host_listeners(&allocator, class.as_ref().unwrap());
 
@@ -2678,7 +2684,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "content");
         assert!(queries[0].first); // viewChild returns single
@@ -2700,7 +2706,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "myRef");
         assert!(queries[0].first);
@@ -2725,7 +2731,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "child");
         assert!(queries[0].first);
@@ -2745,7 +2751,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "items");
         assert!(!queries[0].first); // viewChildren returns multiple
@@ -2765,7 +2771,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "panel");
         assert!(queries[0].first); // contentChild returns single
@@ -2785,7 +2791,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "header");
         assert!(queries[0].first);
@@ -2810,7 +2816,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "tabs");
         assert!(!queries[0].first); // contentChildren returns multiple
@@ -2831,7 +2837,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert!(queries[0].descendants); // Explicitly set to true
     }
@@ -2848,7 +2854,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "portal");
         assert!(queries[0].first); // viewChild returns single
@@ -2868,7 +2874,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "myRef");
         assert!(queries[0].first);
@@ -2893,7 +2899,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 1);
         assert_eq!(queries[0].property_name.as_str(), "content");
         assert!(queries[0].first); // contentChild returns single
@@ -2914,7 +2920,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let queries = extract_view_queries(&allocator, class.as_ref().unwrap());
+        let queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(queries.len(), 2);
         assert_eq!(queries[0].property_name.as_str(), "portal");
         assert!(queries[0].is_signal);
@@ -2940,8 +2946,8 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap());
-        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
+        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
 
         assert_eq!(view_queries.len(), 2);
         // Signal queries come first (Angular's ordering)
@@ -2984,7 +2990,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 2);
 
         // counter: input(0) - optional signal input with default value
@@ -3027,7 +3033,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 6);
 
         // Signal inputs first (in declaration order)
@@ -3092,7 +3098,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 1);
 
         // Signal input transforms are NOT captured (transformFunction: null in Angular's output)
@@ -3127,7 +3133,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         assert_eq!(inputs.len(), 4);
 
         // All should be required signal inputs with NO transform captured
@@ -3176,8 +3182,8 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap());
-        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
+        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
 
         // View queries: query1, query2, query5, query6, query7
         assert_eq!(view_queries.len(), 5);
@@ -3259,8 +3265,8 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap());
-        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
+        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
 
         // Angular ordering: signal queries FIRST, then decorator queries
         // viewQueries: [signalViewChild, decoratorViewChild]
@@ -3390,7 +3396,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         let outputs = extract_output_metadata(&allocator, class.as_ref().unwrap());
 
         // Model creates inputs
@@ -3443,7 +3449,7 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap());
+        let inputs = extract_input_metadata(&allocator, class.as_ref().unwrap(), code);
         let outputs = extract_output_metadata(&allocator, class.as_ref().unwrap());
 
         // Inputs: 2 from model + 2 from @Input = 4
@@ -3502,8 +3508,8 @@ mod tests {
         let class = parse_class(&allocator, code);
         assert!(class.is_some());
 
-        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap());
-        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap());
+        let view_queries = extract_view_queries(&allocator, class.as_ref().unwrap(), code);
+        let content_queries = extract_content_queries(&allocator, class.as_ref().unwrap(), code);
 
         // viewChild.required() creates a required signal query
         assert_eq!(view_queries.len(), 1);

--- a/crates/oxc_angular_compiler/src/injectable/decorator.rs
+++ b/crates/oxc_angular_compiler/src/injectable/decorator.rs
@@ -217,6 +217,7 @@ pub fn find_injectable_decorator_span(class: &Class<'_>) -> Option<Span> {
 pub fn extract_injectable_metadata<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
+    source: &'a str,
 ) -> Option<InjectableMetadata<'a>> {
     let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
     let class_span = class.span;
@@ -240,7 +241,7 @@ pub fn extract_injectable_metadata<'a>(
             use_factory: None,
             use_value: None,
             use_existing: None,
-            deps: extract_constructor_deps(allocator, class),
+            deps: extract_constructor_deps(allocator, class, source),
         });
     }
 
@@ -251,22 +252,22 @@ pub fn extract_injectable_metadata<'a>(
     };
 
     // Extract providedIn (default to 'root' if not specified)
-    let provided_in = extract_provided_in(allocator, config_obj).or(Some(ProvidedInValue::Root));
+    let provided_in = extract_provided_in(allocator, config_obj, source).or(Some(ProvidedInValue::Root));
 
     // Extract useClass
-    let use_class = extract_use_class(allocator, config_obj);
+    let use_class = extract_use_class(allocator, config_obj, source);
 
     // Extract useFactory
-    let use_factory = extract_use_factory(allocator, config_obj);
+    let use_factory = extract_use_factory(allocator, config_obj, source);
 
     // Extract useValue
-    let use_value = extract_use_value(allocator, config_obj);
+    let use_value = extract_use_value(allocator, config_obj, source);
 
     // Extract useExisting
-    let use_existing = extract_use_existing(allocator, config_obj);
+    let use_existing = extract_use_existing(allocator, config_obj, source);
 
     // Extract constructor dependencies
-    let deps = extract_constructor_deps(allocator, class);
+    let deps = extract_constructor_deps(allocator, class, source);
 
     Some(InjectableMetadata {
         class_name,
@@ -302,12 +303,13 @@ fn get_property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<Atom<'a>> {
 fn extract_provided_in<'a>(
     allocator: &'a Allocator,
     config_obj: &'a oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Option<ProvidedInValue<'a>> {
     for prop in &config_obj.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
             if let Some(key_name) = get_property_key_name(&prop.key) {
                 if key_name.as_str() == "providedIn" {
-                    return parse_provided_in_value(allocator, &prop.value);
+                    return parse_provided_in_value(allocator, &prop.value, source);
                 }
             }
         }
@@ -318,6 +320,7 @@ fn extract_provided_in<'a>(
 fn parse_provided_in_value<'a>(
     allocator: &'a Allocator,
     expr: &'a Expression<'a>,
+    source: &'a str,
 ) -> Option<ProvidedInValue<'a>> {
     match expr {
         Expression::StringLiteral(s) => match s.value.as_str() {
@@ -329,7 +332,7 @@ fn parse_provided_in_value<'a>(
         Expression::NullLiteral(_) => Some(ProvidedInValue::None),
         _ => {
             // Check for forwardRef
-            let (expression, is_forward_ref) = extract_forward_ref_or_expression(allocator, expr)?;
+            let (expression, is_forward_ref) = extract_forward_ref_or_expression(allocator, expr, source)?;
             Some(ProvidedInValue::Module { expression, is_forward_ref })
         }
     }
@@ -338,14 +341,15 @@ fn parse_provided_in_value<'a>(
 fn extract_use_class<'a>(
     allocator: &'a Allocator,
     config_obj: &'a oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Option<UseClassMetadata<'a>> {
     for prop in &config_obj.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
             if let Some(key_name) = get_property_key_name(&prop.key) {
                 if key_name.as_str() == "useClass" {
                     let (class_expr, is_forward_ref) =
-                        extract_forward_ref_or_expression(allocator, &prop.value)?;
-                    let deps = extract_deps_from_config(allocator, config_obj);
+                        extract_forward_ref_or_expression(allocator, &prop.value, source)?;
+                    let deps = extract_deps_from_config(allocator, config_obj, source);
                     return Some(UseClassMetadata { class_expr, is_forward_ref, deps });
                 }
             }
@@ -357,13 +361,14 @@ fn extract_use_class<'a>(
 fn extract_use_factory<'a>(
     allocator: &'a Allocator,
     config_obj: &'a oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Option<UseFactoryMetadata<'a>> {
     for prop in &config_obj.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
             if let Some(key_name) = get_property_key_name(&prop.key) {
                 if key_name.as_str() == "useFactory" {
-                    let factory = convert_oxc_expression(allocator, &prop.value)?;
-                    let deps = extract_deps_from_config(allocator, config_obj);
+                    let factory = convert_oxc_expression(allocator, &prop.value, source)?;
+                    let deps = extract_deps_from_config(allocator, config_obj, source);
                     return Some(UseFactoryMetadata { factory, deps });
                 }
             }
@@ -375,12 +380,13 @@ fn extract_use_factory<'a>(
 fn extract_use_value<'a>(
     allocator: &'a Allocator,
     config_obj: &'a oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     for prop in &config_obj.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
             if let Some(key_name) = get_property_key_name(&prop.key) {
                 if key_name.as_str() == "useValue" {
-                    return convert_oxc_expression(allocator, &prop.value);
+                    return convert_oxc_expression(allocator, &prop.value, source);
                 }
             }
         }
@@ -391,13 +397,14 @@ fn extract_use_value<'a>(
 fn extract_use_existing<'a>(
     allocator: &'a Allocator,
     config_obj: &'a oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Option<UseExistingMetadata<'a>> {
     for prop in &config_obj.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
             if let Some(key_name) = get_property_key_name(&prop.key) {
                 if key_name.as_str() == "useExisting" {
                     let (existing, is_forward_ref) =
-                        extract_forward_ref_or_expression(allocator, &prop.value)?;
+                        extract_forward_ref_or_expression(allocator, &prop.value, source)?;
                     return Some(UseExistingMetadata { existing, is_forward_ref });
                 }
             }
@@ -411,6 +418,7 @@ fn extract_use_existing<'a>(
 fn extract_forward_ref_or_expression<'a>(
     allocator: &'a Allocator,
     expr: &'a Expression<'a>,
+    source: &'a str,
 ) -> Option<(OutputExpression<'a>, bool)> {
     // Check if this is forwardRef(() => X)
     if let Expression::CallExpression(call) = expr {
@@ -424,7 +432,7 @@ fn extract_forward_ref_or_expression<'a>(
                             arrow.body.statements.first()
                         {
                             if let Some(expression) =
-                                convert_oxc_expression(allocator, &expr_stmt.expression)
+                                convert_oxc_expression(allocator, &expr_stmt.expression, source)
                             {
                                 return Some((expression, true));
                             }
@@ -434,12 +442,13 @@ fn extract_forward_ref_or_expression<'a>(
             }
         }
     }
-    convert_oxc_expression(allocator, expr).map(|e| (e, false))
+    convert_oxc_expression(allocator, expr, source).map(|e| (e, false))
 }
 
 fn extract_deps_from_config<'a>(
     allocator: &'a Allocator,
     config_obj: &'a oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Vec<'a, DependencyMetadata<'a>> {
     let mut deps = Vec::new_in(allocator);
 
@@ -449,7 +458,7 @@ fn extract_deps_from_config<'a>(
                 if key_name.as_str() == "deps" {
                     if let Expression::ArrayExpression(arr) = &prop.value {
                         for element in &arr.elements {
-                            if let Some(dep) = extract_dependency(allocator, element) {
+                            if let Some(dep) = extract_dependency(allocator, element, source) {
                                 deps.push(dep);
                             }
                         }
@@ -466,12 +475,13 @@ fn extract_deps_from_config<'a>(
 fn extract_dependency<'a>(
     allocator: &'a Allocator,
     element: &'a ArrayExpressionElement<'a>,
+    source: &'a str,
 ) -> Option<DependencyMetadata<'a>> {
     match element {
         ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => None,
         _ => {
             let expr = element.to_expression();
-            convert_oxc_expression(allocator, expr).map(|t| DependencyMetadata {
+            convert_oxc_expression(allocator, expr, source).map(|t| DependencyMetadata {
                 token: t,
                 optional: false,
                 self_: false,
@@ -509,6 +519,7 @@ fn extract_dependency<'a>(
 pub fn extract_constructor_deps<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
+    source: &'a str,
 ) -> Option<Vec<'a, R3DependencyMetadata<'a>>> {
     // Find the constructor method
     let constructor = class.body.body.iter().find_map(|element| {
@@ -525,7 +536,7 @@ pub fn extract_constructor_deps<'a>(
     let mut deps = Vec::with_capacity_in(params.items.len(), allocator);
 
     for param in &params.items {
-        let dep = extract_param_dependency(allocator, param);
+        let dep = extract_param_dependency(allocator, param, source);
         deps.push(dep);
     }
 
@@ -536,6 +547,7 @@ pub fn extract_constructor_deps<'a>(
 fn extract_param_dependency<'a>(
     allocator: &'a Allocator,
     param: &oxc_ast::ast::FormalParameter<'a>,
+    source: &'a str,
 ) -> R3DependencyMetadata<'a> {
     // Extract flags and @Inject token from decorators
     let mut optional = false;
@@ -552,7 +564,7 @@ fn extract_param_dependency<'a>(
                     // @Inject(TOKEN) - extract the token
                     if let Expression::CallExpression(call) = &decorator.expression {
                         if let Some(arg) = call.arguments.first() {
-                            inject_token = convert_oxc_expression(allocator, arg.to_expression());
+                            inject_token = convert_oxc_expression(allocator, arg.to_expression(), source);
                         }
                     }
                 }
@@ -663,7 +675,7 @@ mod tests {
 
         for stmt in &program.body {
             if let oxc_ast::ast::Statement::ClassDeclaration(class) = stmt {
-                return extract_injectable_metadata(allocator, class);
+                return extract_injectable_metadata(allocator, class, source);
             }
         }
         None

--- a/crates/oxc_angular_compiler/src/injectable/definition.rs
+++ b/crates/oxc_angular_compiler/src/injectable/definition.rs
@@ -368,7 +368,7 @@ mod tests {
         });
 
         let class = class.expect("Should find class declaration");
-        let metadata = extract_injectable_metadata(&allocator, class);
+        let metadata = extract_injectable_metadata(&allocator, class, code);
         let metadata = metadata.expect("Should extract Injectable metadata");
 
         // Verify deps are extracted
@@ -424,7 +424,7 @@ mod tests {
         });
 
         let class = class.expect("Should find class declaration");
-        let metadata = extract_injectable_metadata(&allocator, class);
+        let metadata = extract_injectable_metadata(&allocator, class, code);
         let metadata = metadata.expect("Should extract Injectable metadata");
 
         // Verify no deps (no constructor)
@@ -469,7 +469,7 @@ mod tests {
         });
 
         let class = class.expect("Should find class declaration");
-        let metadata = extract_injectable_metadata(&allocator, class);
+        let metadata = extract_injectable_metadata(&allocator, class, code);
         let metadata = metadata.expect("Should extract Injectable metadata");
 
         // Generate definition

--- a/crates/oxc_angular_compiler/src/ir/expression.rs
+++ b/crates/oxc_angular_compiler/src/ir/expression.rs
@@ -2075,7 +2075,8 @@ fn transform_expressions_in_output_expression<'a, F>(
         | OutputExpression::External(_)
         | OutputExpression::LocalizedString(_)
         | OutputExpression::WrappedNode(_)
-        | OutputExpression::DynamicImport(_) => {}
+        | OutputExpression::DynamicImport(_)
+        | OutputExpression::RawSource(_) => {}
     }
 }
 

--- a/crates/oxc_angular_compiler/src/ng_module/decorator.rs
+++ b/crates/oxc_angular_compiler/src/ng_module/decorator.rs
@@ -180,6 +180,7 @@ impl<'a> NgModuleMetadata<'a> {
 pub fn extract_ng_module_metadata<'a>(
     allocator: &'a Allocator,
     class: &'a Class<'a>,
+    source: &'a str,
 ) -> Option<NgModuleMetadata<'a>> {
     // Get the class name
     let class_name: Atom<'a> = class.id.as_ref()?.name.clone().into();
@@ -235,7 +236,7 @@ pub fn extract_ng_module_metadata<'a>(
                     // Also store the raw imports expression for ɵinj generation.
                     // This preserves call expressions like StoreModule.forRoot(...)
                     // and spread elements that are dropped by extract_reference_array.
-                    metadata.raw_imports_expr = convert_oxc_expression(allocator, &prop.value);
+                    metadata.raw_imports_expr = convert_oxc_expression(allocator, &prop.value, source);
                 }
                 "exports" => {
                     let (identifiers, has_forward_refs) =
@@ -246,7 +247,7 @@ pub fn extract_ng_module_metadata<'a>(
                     }
                 }
                 "providers" => {
-                    metadata.providers = convert_oxc_expression(allocator, &prop.value);
+                    metadata.providers = convert_oxc_expression(allocator, &prop.value, source);
                 }
                 "bootstrap" => {
                     let (identifiers, has_forward_refs) =
@@ -571,7 +572,7 @@ mod tests {
             };
 
             if let Some(class) = class {
-                if let Some(metadata) = extract_ng_module_metadata(&allocator, class) {
+                if let Some(metadata) = extract_ng_module_metadata(&allocator, class, code) {
                     found_metadata = Some(metadata);
                     break;
                 }

--- a/crates/oxc_angular_compiler/src/ng_module/definition.rs
+++ b/crates/oxc_angular_compiler/src/ng_module/definition.rs
@@ -538,7 +538,7 @@ mod tests {
         });
 
         let class = class.expect("Should find class declaration");
-        let metadata = extract_ng_module_metadata(&allocator, class);
+        let metadata = extract_ng_module_metadata(&allocator, class, code);
         let metadata = metadata.expect("Should extract NgModule metadata");
 
         let definition = generate_ng_module_definition_from_decorator(&allocator, &metadata);
@@ -578,7 +578,7 @@ mod tests {
         });
 
         let class = class.expect("Should find class declaration");
-        let metadata = extract_ng_module_metadata(&allocator, class);
+        let metadata = extract_ng_module_metadata(&allocator, class, code);
         let metadata = metadata.expect("Should extract NgModule metadata");
 
         // Verify deps are extracted

--- a/crates/oxc_angular_compiler/src/output/ast.rs
+++ b/crates/oxc_angular_compiler/src/output/ast.rs
@@ -460,6 +460,10 @@ pub enum OutputExpression<'a> {
     // Spread element (for array spread)
     /// Spread element (...expr).
     SpreadElement(Box<'a, SpreadElementExpr<'a>>),
+
+    // Raw source text (verbatim pass-through)
+    /// Raw source text for unconvertible expressions.
+    RawSource(Box<'a, RawSourceExpr<'a>>),
 }
 
 /// Literal expression.
@@ -833,6 +837,18 @@ pub struct SpreadElementExpr<'a> {
     pub source_span: Option<Span>,
 }
 
+/// Raw source text expression (verbatim pass-through).
+///
+/// Used when an OXC expression cannot be fully converted to OutputExpression.
+/// The emitter prints the source text as-is, preserving the original code.
+#[derive(Debug)]
+pub struct RawSourceExpr<'a> {
+    /// The original source text.
+    pub source: Atom<'a>,
+    /// Source span.
+    pub source_span: Option<Span>,
+}
+
 // ============================================================================
 // Statements
 // ============================================================================
@@ -947,6 +963,7 @@ impl<'a> OutputExpression<'a> {
             OutputExpression::LiteralArray(arr) => arr.entries.iter().all(|e| e.is_constant()),
             OutputExpression::LiteralMap(map) => map.entries.iter().all(|e| e.value.is_constant()),
             OutputExpression::RegularExpressionLiteral(_) => true,
+            OutputExpression::RawSource(_) => false,
             _ => false,
         }
     }
@@ -1071,6 +1088,10 @@ impl<'a> OutputExpression<'a> {
             // Spread elements
             (OutputExpression::SpreadElement(a), OutputExpression::SpreadElement(b)) => {
                 a.expr.is_equivalent(&b.expr)
+            }
+            // Raw source
+            (OutputExpression::RawSource(a), OutputExpression::RawSource(b)) => {
+                a.source == b.source
             }
             _ => false,
         }
@@ -1400,6 +1421,10 @@ impl<'a> OutputExpression<'a> {
                     expr: Box::new_in(e.expr.clone_in(allocator), allocator),
                     source_span: e.source_span,
                 },
+                allocator,
+            )),
+            OutputExpression::RawSource(e) => OutputExpression::RawSource(Box::new_in(
+                RawSourceExpr { source: e.source.clone(), source_span: e.source_span },
                 allocator,
             )),
         }
@@ -1774,6 +1799,9 @@ pub trait RecursiveOutputAstVisitor<'a> {
         self.visit_expression(&expr.expr);
     }
 
+    /// Visit a raw source expression.
+    fn visit_raw_source(&mut self, _expr: &RawSourceExpr<'a>) {}
+
     /// Visit any output expression (dispatches to specific visit methods).
     fn visit_expression(&mut self, expr: &OutputExpression<'a>) {
         match expr {
@@ -1804,6 +1832,7 @@ pub trait RecursiveOutputAstVisitor<'a> {
             OutputExpression::WrappedNode(e) => self.visit_wrapped_node(e),
             OutputExpression::WrappedIrNode(e) => self.visit_wrapped_ir_node(e),
             OutputExpression::SpreadElement(e) => self.visit_spread_element(e),
+            OutputExpression::RawSource(e) => self.visit_raw_source(e),
         }
     }
 

--- a/crates/oxc_angular_compiler/src/output/emitter.rs
+++ b/crates/oxc_angular_compiler/src/output/emitter.rs
@@ -355,6 +355,7 @@ fn get_source_span(expr: &OutputExpression<'_>) -> Option<Span> {
         OutputExpression::WrappedNode(e) => e.source_span,
         OutputExpression::WrappedIrNode(e) => e.source_span,
         OutputExpression::SpreadElement(e) => e.source_span,
+        OutputExpression::RawSource(e) => e.source_span,
     }
 }
 
@@ -874,6 +875,9 @@ impl JsEmitter {
             OutputExpression::SpreadElement(e) => {
                 ctx.print("...");
                 self.visit_expression(&e.expr, ctx);
+            }
+            OutputExpression::RawSource(e) => {
+                ctx.print_with_span(&e.source, source_span);
             }
         }
     }

--- a/crates/oxc_angular_compiler/src/output/oxc_converter.rs
+++ b/crates/oxc_angular_compiler/src/output/oxc_converter.rs
@@ -16,7 +16,7 @@ use oxc_ast::ast::{
     Argument, ArrayExpressionElement, BindingPattern, Expression, ObjectPropertyKind, PropertyKey,
     UnaryOperator as OxcUnaryOperator,
 };
-use oxc_span::Atom;
+use oxc_span::{Atom, GetSpan};
 
 use super::ast::{
     ArrowFunctionBody, ArrowFunctionExpr, BinaryOperator, BinaryOperatorExpr, CommaExpr,
@@ -24,8 +24,25 @@ use super::ast::{
     LiteralMapEntry, LiteralMapExpr, LiteralValue, NotExpr, OutputExpression, OutputStatement,
     ParenthesizedExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, SpreadElementExpr,
     TemplateLiteralElement, TemplateLiteralExpr, TypeofExpr, UnaryOperator, UnaryOperatorExpr,
-    VoidExpr,
+    RawSourceExpr, VoidExpr,
 };
+
+// ============================================================================
+// Raw Source Fallback
+// ============================================================================
+
+/// Create a `RawSource` expression from a source span.
+fn raw_source_from_span<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    span: oxc_span::Span,
+) -> OutputExpression<'a> {
+    let text = &source[span.start as usize..span.end as usize];
+    OutputExpression::RawSource(Box::new_in(
+        RawSourceExpr { source: Atom::from(text), source_span: Some(span) },
+        allocator,
+    ))
+}
 
 // ============================================================================
 // Main Conversion Function
@@ -34,19 +51,22 @@ use super::ast::{
 /// Convert an OXC Expression to an OutputExpression.
 ///
 /// This handles common expression types used in Angular decorator properties.
-/// Returns `None` if the expression type is not supported.
+/// When full conversion fails, falls back to `RawSource` which preserves the
+/// original source text verbatim.
 ///
 /// # Arguments
 /// * `allocator` - The allocator for creating new nodes
 /// * `expr` - The OXC expression to convert
+/// * `source` - The original source text (used for `RawSource` fallback)
 ///
 /// # Returns
-/// `Some(OutputExpression)` if conversion succeeded, `None` otherwise.
+/// `Some(OutputExpression)` if conversion or fallback succeeded, `None` otherwise.
 pub fn convert_oxc_expression<'a>(
     allocator: &'a Allocator,
     expr: &Expression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
-    match expr {
+    let result = match expr {
         // Literals
         Expression::BooleanLiteral(lit) => Some(OutputExpression::Literal(Box::new_in(
             LiteralExpr { value: LiteralValue::Boolean(lit.value), source_span: None },
@@ -75,25 +95,25 @@ pub fn convert_oxc_expression<'a>(
         ))),
 
         // Array expressions
-        Expression::ArrayExpression(arr) => convert_array_expression(allocator, arr),
+        Expression::ArrayExpression(arr) => convert_array_expression(allocator, arr, source),
 
         // Object expressions
-        Expression::ObjectExpression(obj) => convert_object_expression(allocator, obj),
+        Expression::ObjectExpression(obj) => convert_object_expression(allocator, obj, source),
 
         // Call expressions
-        Expression::CallExpression(call) => convert_call_expression(allocator, call),
+        Expression::CallExpression(call) => convert_call_expression(allocator, call, source),
 
         // New expressions
-        Expression::NewExpression(new_expr) => convert_new_expression(allocator, new_expr),
+        Expression::NewExpression(new_expr) => convert_new_expression(allocator, new_expr, source),
 
         // Arrow function expressions
         Expression::ArrowFunctionExpression(arrow) => {
-            convert_arrow_function_expression(allocator, arrow)
+            convert_arrow_function_expression(allocator, arrow, source)
         }
 
         // Member expressions
         Expression::StaticMemberExpression(member) => {
-            let receiver = convert_oxc_expression(allocator, &member.object)?;
+            let receiver = convert_oxc_expression(allocator, &member.object, source)?;
             Some(OutputExpression::ReadProp(Box::new_in(
                 ReadPropExpr {
                     receiver: Box::new_in(receiver, allocator),
@@ -106,8 +126,8 @@ pub fn convert_oxc_expression<'a>(
         }
 
         Expression::ComputedMemberExpression(member) => {
-            let receiver = convert_oxc_expression(allocator, &member.object)?;
-            let index = convert_oxc_expression(allocator, &member.expression)?;
+            let receiver = convert_oxc_expression(allocator, &member.object, source)?;
+            let index = convert_oxc_expression(allocator, &member.expression, source)?;
             Some(OutputExpression::ReadKey(Box::new_in(
                 ReadKeyExpr {
                     receiver: Box::new_in(receiver, allocator),
@@ -120,12 +140,12 @@ pub fn convert_oxc_expression<'a>(
         }
 
         // Chain expression (optional chaining)
-        Expression::ChainExpression(chain) => convert_chain_element(allocator, &chain.expression),
+        Expression::ChainExpression(chain) => convert_chain_element(allocator, &chain.expression, source),
 
         // Binary expressions
         Expression::BinaryExpression(bin) => {
-            let lhs = convert_oxc_expression(allocator, &bin.left)?;
-            let rhs = convert_oxc_expression(allocator, &bin.right)?;
+            let lhs = convert_oxc_expression(allocator, &bin.left, source)?;
+            let rhs = convert_oxc_expression(allocator, &bin.right, source)?;
             let operator = convert_oxc_binary_operator(bin.operator)?;
             Some(OutputExpression::BinaryOperator(Box::new_in(
                 BinaryOperatorExpr {
@@ -140,8 +160,8 @@ pub fn convert_oxc_expression<'a>(
 
         // Logical expressions (&&, ||, ??)
         Expression::LogicalExpression(logical) => {
-            let lhs = convert_oxc_expression(allocator, &logical.left)?;
-            let rhs = convert_oxc_expression(allocator, &logical.right)?;
+            let lhs = convert_oxc_expression(allocator, &logical.left, source)?;
+            let rhs = convert_oxc_expression(allocator, &logical.right, source)?;
             let operator = match logical.operator {
                 oxc_ast::ast::LogicalOperator::And => BinaryOperator::And,
                 oxc_ast::ast::LogicalOperator::Or => BinaryOperator::Or,
@@ -159,13 +179,13 @@ pub fn convert_oxc_expression<'a>(
         }
 
         // Unary expressions
-        Expression::UnaryExpression(unary) => convert_unary_expression(allocator, unary),
+        Expression::UnaryExpression(unary) => convert_unary_expression(allocator, unary, source),
 
         // Conditional expressions (ternary)
         Expression::ConditionalExpression(cond) => {
-            let condition = convert_oxc_expression(allocator, &cond.test)?;
-            let true_case = convert_oxc_expression(allocator, &cond.consequent)?;
-            let false_case = convert_oxc_expression(allocator, &cond.alternate)?;
+            let condition = convert_oxc_expression(allocator, &cond.test, source)?;
+            let true_case = convert_oxc_expression(allocator, &cond.consequent, source)?;
+            let false_case = convert_oxc_expression(allocator, &cond.alternate, source)?;
             Some(OutputExpression::Conditional(Box::new_in(
                 ConditionalExpr {
                     condition: Box::new_in(condition, allocator),
@@ -178,11 +198,11 @@ pub fn convert_oxc_expression<'a>(
         }
 
         // Template literals
-        Expression::TemplateLiteral(tpl) => convert_template_literal(allocator, tpl),
+        Expression::TemplateLiteral(tpl) => convert_template_literal(allocator, tpl, source),
 
         // Parenthesized expressions
         Expression::ParenthesizedExpression(paren) => {
-            let inner = convert_oxc_expression(allocator, &paren.expression)?;
+            let inner = convert_oxc_expression(allocator, &paren.expression, source)?;
             Some(OutputExpression::Parenthesized(Box::new_in(
                 ParenthesizedExpr { expr: Box::new_in(inner, allocator), source_span: None },
                 allocator,
@@ -193,7 +213,7 @@ pub fn convert_oxc_expression<'a>(
         Expression::SequenceExpression(seq) => {
             let mut parts = OxcVec::with_capacity_in(seq.expressions.len(), allocator);
             for expr in &seq.expressions {
-                parts.push(convert_oxc_expression(allocator, expr)?);
+                parts.push(convert_oxc_expression(allocator, expr, source)?);
             }
             Some(OutputExpression::Comma(Box::new_in(
                 CommaExpr { parts, source_span: None },
@@ -209,23 +229,24 @@ pub fn convert_oxc_expression<'a>(
 
         // TypeScript type expressions - unwrap the inner expression
         // These don't affect runtime behavior, just compile-time type checking
-        Expression::TSAsExpression(ts_as) => convert_oxc_expression(allocator, &ts_as.expression),
+        Expression::TSAsExpression(ts_as) => convert_oxc_expression(allocator, &ts_as.expression, source),
         Expression::TSTypeAssertion(ts_assert) => {
-            convert_oxc_expression(allocator, &ts_assert.expression)
+            convert_oxc_expression(allocator, &ts_assert.expression, source)
         }
         Expression::TSSatisfiesExpression(ts_satisfies) => {
-            convert_oxc_expression(allocator, &ts_satisfies.expression)
+            convert_oxc_expression(allocator, &ts_satisfies.expression, source)
         }
         Expression::TSNonNullExpression(ts_non_null) => {
-            convert_oxc_expression(allocator, &ts_non_null.expression)
+            convert_oxc_expression(allocator, &ts_non_null.expression, source)
         }
         Expression::TSInstantiationExpression(ts_inst) => {
-            convert_oxc_expression(allocator, &ts_inst.expression)
+            convert_oxc_expression(allocator, &ts_inst.expression, source)
         }
 
-        // Unsupported expressions - return None
+        // Unsupported expressions
         _ => None,
-    }
+    };
+    result.or_else(|| Some(raw_source_from_span(allocator, source, expr.span())))
 }
 
 // ============================================================================
@@ -236,6 +257,7 @@ pub fn convert_oxc_expression<'a>(
 fn convert_array_expression<'a>(
     allocator: &'a Allocator,
     arr: &oxc_ast::ast::ArrayExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     let mut entries = OxcVec::with_capacity_in(arr.elements.len(), allocator);
 
@@ -243,7 +265,7 @@ fn convert_array_expression<'a>(
         match element {
             ArrayExpressionElement::SpreadElement(spread) => {
                 // Convert the inner expression and wrap it in SpreadElement
-                let inner_expr = convert_oxc_expression(allocator, &spread.argument)?;
+                let inner_expr = convert_oxc_expression(allocator, &spread.argument, source)?;
                 let spread_expr = OutputExpression::SpreadElement(Box::new_in(
                     SpreadElementExpr {
                         expr: Box::new_in(inner_expr, allocator),
@@ -263,7 +285,7 @@ fn convert_array_expression<'a>(
             _ => {
                 // Regular expression element
                 let expr_ref = element.to_expression();
-                let converted = convert_oxc_expression(allocator, expr_ref)?;
+                let converted = convert_oxc_expression(allocator, expr_ref, source)?;
                 entries.push(converted);
             }
         }
@@ -279,6 +301,7 @@ fn convert_array_expression<'a>(
 fn convert_object_expression<'a>(
     allocator: &'a Allocator,
     obj: &oxc_ast::ast::ObjectExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     let mut entries = OxcVec::with_capacity_in(obj.properties.len(), allocator);
 
@@ -301,7 +324,7 @@ fn convert_object_expression<'a>(
                 };
 
                 // Convert the value
-                let value = convert_oxc_expression(allocator, &p.value)?;
+                let value = convert_oxc_expression(allocator, &p.value, source)?;
 
                 entries.push(LiteralMapEntry { key, value, quoted });
             }
@@ -323,8 +346,9 @@ fn convert_object_expression<'a>(
 fn convert_call_expression<'a>(
     allocator: &'a Allocator,
     call: &oxc_ast::ast::CallExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
-    convert_call_expression_with_optional(allocator, call, call.optional)
+    convert_call_expression_with_optional(allocator, call, call.optional, source)
 }
 
 /// Convert an OXC call expression to an OutputExpression with explicit optional flag.
@@ -332,9 +356,10 @@ fn convert_call_expression_with_optional<'a>(
     allocator: &'a Allocator,
     call: &oxc_ast::ast::CallExpression<'a>,
     optional: bool,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     // Convert the callee
-    let fn_expr = convert_oxc_expression(allocator, &call.callee)?;
+    let fn_expr = convert_oxc_expression(allocator, &call.callee, source)?;
 
     // Convert arguments
     let mut args = OxcVec::with_capacity_in(call.arguments.len(), allocator);
@@ -342,12 +367,12 @@ fn convert_call_expression_with_optional<'a>(
         match arg {
             Argument::SpreadElement(spread) => {
                 // Handle spread arguments
-                let expr = convert_oxc_expression(allocator, &spread.argument)?;
+                let expr = convert_oxc_expression(allocator, &spread.argument, source)?;
                 args.push(expr);
             }
             _ => {
                 let expr = arg.to_expression();
-                let converted = convert_oxc_expression(allocator, expr)?;
+                let converted = convert_oxc_expression(allocator, expr, source)?;
                 args.push(converted);
             }
         }
@@ -369,21 +394,22 @@ fn convert_call_expression_with_optional<'a>(
 fn convert_new_expression<'a>(
     allocator: &'a Allocator,
     new_expr: &oxc_ast::ast::NewExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     // Convert the callee (class expression)
-    let class_expr = convert_oxc_expression(allocator, &new_expr.callee)?;
+    let class_expr = convert_oxc_expression(allocator, &new_expr.callee, source)?;
 
     // Convert arguments
     let mut args = OxcVec::with_capacity_in(new_expr.arguments.len(), allocator);
     for arg in &new_expr.arguments {
         match arg {
             Argument::SpreadElement(spread) => {
-                let expr = convert_oxc_expression(allocator, &spread.argument)?;
+                let expr = convert_oxc_expression(allocator, &spread.argument, source)?;
                 args.push(expr);
             }
             _ => {
                 let expr = arg.to_expression();
-                let converted = convert_oxc_expression(allocator, expr)?;
+                let converted = convert_oxc_expression(allocator, expr, source)?;
                 args.push(converted);
             }
         }
@@ -399,6 +425,7 @@ fn convert_new_expression<'a>(
 fn convert_arrow_function_expression<'a>(
     allocator: &'a Allocator,
     arrow: &oxc_ast::ast::ArrowFunctionExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     // Convert parameters
     let mut params = OxcVec::with_capacity_in(arrow.params.items.len(), allocator);
@@ -417,7 +444,7 @@ fn convert_arrow_function_expression<'a>(
         // Expression body: () => expr
         let expr_body = arrow.body.statements.first()?;
         if let oxc_ast::ast::Statement::ExpressionStatement(expr_stmt) = expr_body {
-            let converted = convert_oxc_expression(allocator, &expr_stmt.expression)?;
+            let converted = convert_oxc_expression(allocator, &expr_stmt.expression, source)?;
             ArrowFunctionBody::Expression(Box::new_in(converted, allocator))
         } else {
             return None;
@@ -426,9 +453,7 @@ fn convert_arrow_function_expression<'a>(
         // Block body: () => { ... }
         let mut statements = OxcVec::with_capacity_in(arrow.body.statements.len(), allocator);
         for stmt in &arrow.body.statements {
-            if let Some(output_stmt) = convert_statement(allocator, stmt) {
-                statements.push(output_stmt);
-            }
+            statements.push(convert_statement(allocator, stmt, source)?);
         }
         ArrowFunctionBody::Statements(statements)
     };
@@ -443,6 +468,7 @@ fn convert_arrow_function_expression<'a>(
 fn convert_statement<'a>(
     allocator: &'a Allocator,
     stmt: &oxc_ast::ast::Statement<'a>,
+    source: &'a str,
 ) -> Option<OutputStatement<'a>> {
     match stmt {
         oxc_ast::ast::Statement::ReturnStatement(ret) => {
@@ -450,7 +476,7 @@ fn convert_statement<'a>(
             let value = ret
                 .argument
                 .as_ref()
-                .and_then(|expr| convert_oxc_expression(allocator, expr))
+                .and_then(|expr| convert_oxc_expression(allocator, expr, source))
                 .unwrap_or_else(|| {
                     OutputExpression::Literal(Box::new_in(
                         LiteralExpr { value: LiteralValue::Undefined, source_span: None },
@@ -463,7 +489,7 @@ fn convert_statement<'a>(
             )))
         }
         oxc_ast::ast::Statement::ExpressionStatement(expr_stmt) => {
-            let expr = convert_oxc_expression(allocator, &expr_stmt.expression)?;
+            let expr = convert_oxc_expression(allocator, &expr_stmt.expression, source)?;
             Some(OutputStatement::Expression(Box::new_in(
                 super::ast::ExpressionStatement { expr, source_span: None },
                 allocator,
@@ -478,8 +504,9 @@ fn convert_statement<'a>(
 fn convert_unary_expression<'a>(
     allocator: &'a Allocator,
     unary: &oxc_ast::ast::UnaryExpression<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
-    let expr = convert_oxc_expression(allocator, &unary.argument)?;
+    let expr = convert_oxc_expression(allocator, &unary.argument, source)?;
 
     match unary.operator {
         OxcUnaryOperator::LogicalNot => Some(OutputExpression::Not(Box::new_in(
@@ -521,6 +548,7 @@ fn convert_unary_expression<'a>(
 fn convert_template_literal<'a>(
     allocator: &'a Allocator,
     tpl: &oxc_ast::ast::TemplateLiteral<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     // Convert quasis to template literal elements
     let mut elements = OxcVec::with_capacity_in(tpl.quasis.len(), allocator);
@@ -538,7 +566,7 @@ fn convert_template_literal<'a>(
     // Convert expressions
     let mut expressions = OxcVec::with_capacity_in(tpl.expressions.len(), allocator);
     for expr in &tpl.expressions {
-        expressions.push(convert_oxc_expression(allocator, expr)?);
+        expressions.push(convert_oxc_expression(allocator, expr, source)?);
     }
 
     Some(OutputExpression::TemplateLiteral(Box::new_in(
@@ -554,21 +582,22 @@ fn convert_template_literal<'a>(
 fn convert_chain_element<'a>(
     allocator: &'a Allocator,
     element: &oxc_ast::ast::ChainElement<'a>,
+    source: &'a str,
 ) -> Option<OutputExpression<'a>> {
     use oxc_ast::ast::ChainElement;
 
     match element {
         ChainElement::CallExpression(call) => {
             // For call expressions within a chain, the optional flag is already set on the call
-            convert_call_expression_with_optional(allocator, call, call.optional)
+            convert_call_expression_with_optional(allocator, call, call.optional, source)
         }
         ChainElement::TSNonNullExpression(ts_non_null) => {
             // TypeScript non-null assertion (!) - just convert the inner expression
-            convert_oxc_expression(allocator, &ts_non_null.expression)
+            convert_oxc_expression(allocator, &ts_non_null.expression, source)
         }
         ChainElement::ComputedMemberExpression(member) => {
-            let receiver = convert_oxc_expression(allocator, &member.object)?;
-            let index = convert_oxc_expression(allocator, &member.expression)?;
+            let receiver = convert_oxc_expression(allocator, &member.object, source)?;
+            let index = convert_oxc_expression(allocator, &member.expression, source)?;
             Some(OutputExpression::ReadKey(Box::new_in(
                 ReadKeyExpr {
                     receiver: Box::new_in(receiver, allocator),
@@ -580,7 +609,7 @@ fn convert_chain_element<'a>(
             )))
         }
         ChainElement::StaticMemberExpression(member) => {
-            let receiver = convert_oxc_expression(allocator, &member.object)?;
+            let receiver = convert_oxc_expression(allocator, &member.object, source)?;
             Some(OutputExpression::ReadProp(Box::new_in(
                 ReadPropExpr {
                     receiver: Box::new_in(receiver, allocator),
@@ -648,7 +677,7 @@ mod tests {
     fn test_convert_string_literal() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, r#""hello""#);
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::Literal(lit)) = result {
             assert!(matches!(lit.value, LiteralValue::String(_)));
@@ -661,7 +690,7 @@ mod tests {
     fn test_convert_number_literal() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "42");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::Literal(lit)) = result {
             if let LiteralValue::Number(n) = lit.value {
@@ -678,7 +707,7 @@ mod tests {
     fn test_convert_identifier() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "myVar");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::ReadVar(var)) = result {
             assert_eq!(var.name.as_str(), "myVar");
@@ -691,7 +720,7 @@ mod tests {
     fn test_convert_array_expression() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "[1, 2, 3]");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::LiteralArray(arr)) = result {
             assert_eq!(arr.entries.len(), 3);
@@ -704,7 +733,7 @@ mod tests {
     fn test_convert_object_expression() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "{ a: 1, b: 2 }");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::LiteralMap(map)) = result {
             assert_eq!(map.entries.len(), 2);
@@ -717,7 +746,7 @@ mod tests {
     fn test_convert_call_expression() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "foo(1, 2)");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::InvokeFunction(call)) = result {
             assert_eq!(call.args.len(), 2);
@@ -730,7 +759,7 @@ mod tests {
     fn test_convert_member_expression() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "obj.prop");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::ReadProp(prop)) = result {
             assert_eq!(prop.name.as_str(), "prop");
@@ -743,7 +772,7 @@ mod tests {
     fn test_convert_spread_in_array() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "[...arr, 1, 2]");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::LiteralArray(arr)) = result {
             assert_eq!(arr.entries.len(), 3);
@@ -768,7 +797,7 @@ mod tests {
     fn test_convert_multiple_spreads_in_array() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "[...a, ...b, c]");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::LiteralArray(arr)) = result {
             assert_eq!(arr.entries.len(), 3);
@@ -786,7 +815,7 @@ mod tests {
     fn test_convert_optional_chaining_property() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "obj?.prop");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::ReadProp(prop)) = result {
             assert_eq!(prop.name.as_str(), "prop");
@@ -800,7 +829,7 @@ mod tests {
     fn test_convert_optional_chaining_computed() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "obj?.[key]");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::ReadKey(key)) = result {
             assert!(key.optional, "Expected optional to be true for ?.[");
@@ -813,7 +842,7 @@ mod tests {
     fn test_convert_optional_chaining_call() {
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "fn?.()");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some());
         if let Some(OutputExpression::InvokeFunction(call)) = result {
             assert!(call.optional, "Expected optional to be true for ?.()");
@@ -827,7 +856,7 @@ mod tests {
         // Test a longer optional chain like: val?.trim().toLowerCase()
         let allocator = Allocator::default();
         let expr = parse_expression(&allocator, "val?.trim().toLowerCase()");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some(), "Failed to convert optional chain expression");
 
         // The expression structure is:
@@ -848,7 +877,7 @@ mod tests {
         let source_type = SourceType::ts();
         let parser = Parser::new(&allocator, "(val) => val?.trim().toLowerCase()", source_type);
         let expr = parser.parse_expression().expect("Failed to parse expression");
-        let result = convert_oxc_expression(&allocator, &expr);
+        let result = convert_oxc_expression(&allocator, &expr, "");
         assert!(result.is_some(), "Failed to convert arrow function with optional chain");
     }
 }

--- a/crates/oxc_angular_compiler/src/pipeline/phases/allocate_slots.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/allocate_slots.rs
@@ -768,7 +768,8 @@ fn propagate_slots_to_expressions(
             | OutputExpression::External(_)
             | OutputExpression::ReadVar(_)
             | OutputExpression::RegularExpressionLiteral(_)
-            | OutputExpression::WrappedNode(_) => {}
+            | OutputExpression::WrappedNode(_)
+            | OutputExpression::RawSource(_) => {}
         }
     }
 

--- a/crates/oxc_angular_compiler/src/pipeline/phases/chaining.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/chaining.rs
@@ -816,6 +816,10 @@ fn clone_expression<'a>(
             },
             allocator,
         )),
+        OutputExpression::RawSource(e) => OutputExpression::RawSource(Box::new_in(
+            RawSourceExpr { source: e.source.clone(), source_span: e.source_span },
+            allocator,
+        )),
     }
 }
 

--- a/crates/oxc_angular_compiler/src/pipeline/phases/generate_advance.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/generate_advance.rs
@@ -292,7 +292,8 @@ fn get_slot_dependency_from_output_expr(expr: &OutputExpression<'_>) -> Option<X
         | OutputExpression::ArrowFunction(_)
         | OutputExpression::Instantiate(_)
         | OutputExpression::DynamicImport(_)
-        | OutputExpression::LocalizedString(_) => None,
+        | OutputExpression::LocalizedString(_)
+        | OutputExpression::RawSource(_) => None,
     }
 }
 

--- a/crates/oxc_angular_compiler/src/pipeline/phases/var_counting.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/var_counting.rs
@@ -841,7 +841,8 @@ fn assign_var_offsets_in_output_expression(
         | OutputExpression::External(_)
         | OutputExpression::ReadVar(_)
         | OutputExpression::RegularExpressionLiteral(_)
-        | OutputExpression::WrappedNode(_) => {}
+        | OutputExpression::WrappedNode(_)
+        | OutputExpression::RawSource(_) => {}
     }
 }
 

--- a/crates/oxc_angular_compiler/src/pipeline/phases/variable_optimization.rs
+++ b/crates/oxc_angular_compiler/src/pipeline/phases/variable_optimization.rs
@@ -3095,7 +3095,8 @@ fn transform_expressions_in_output_expression<'a, F>(
         | OutputExpression::LocalizedString(_)
         | OutputExpression::WrappedNode(_)
         | OutputExpression::DynamicImport(_)
-        | OutputExpression::RegularExpressionLiteral(_) => {}
+        | OutputExpression::RegularExpressionLiteral(_)
+        | OutputExpression::RawSource(_) => {}
     }
 }
 

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -7833,3 +7833,66 @@ fn test_property_singleton_interpolation_with_sanitizer_angular_v19() {
     assert!(js.contains("ɵɵsanitizeUrl"), "Should include ɵɵsanitizeUrl sanitizer. Got:\n{js}");
     insta::assert_snapshot!("property_singleton_interpolation_with_sanitizer_v19", js);
 }
+
+#[test]
+fn test_use_factory_with_if_statement_preserved() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Injectable } from '@angular/core';
+
+const isProd = true;
+
+@Injectable({
+    providedIn: 'root',
+    useFactory: () => { if (isProd) { return new ProdService(); } return new DevService(); }
+})
+export class MyService {}
+"#;
+
+    let options = ComponentTransformOptions::default();
+    let result = transform_angular_file(&allocator, "factory.service.ts", source, &options, None);
+    assert!(!result.has_errors(), "Should compile without errors: {:?}", result.diagnostics);
+
+    // The if statement should be preserved via raw source fallback
+    assert!(
+        result.code.contains("if (isProd)"),
+        "Should preserve if statement in factory body via raw source. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("ProdService"),
+        "Should preserve ProdService reference. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("DevService"),
+        "Should preserve DevService reference. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_providers_with_complex_expression_preserved() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'my-comp',
+    template: '<div></div>',
+    providers: [{ provide: 'TOKEN', useFactory: () => { if (true) { return 1; } return 2; } }]
+})
+export class MyComponent {}
+"#;
+
+    let options = ComponentTransformOptions::default();
+    let result = transform_angular_file(&allocator, "comp.ts", source, &options, None);
+    assert!(!result.has_errors(), "Should compile without errors: {:?}", result.diagnostics);
+
+    // The complex expression should be preserved in the providers output
+    assert!(
+        result.code.contains("if (true)"),
+        "Should preserve complex expression in providers via raw source. Got:\n{}",
+        result.code
+    );
+}

--- a/napi/angular-compiler/src/lib.rs
+++ b/napi/angular-compiler/src/lib.rs
@@ -753,7 +753,7 @@ pub fn extract_component_urls_sync(source: String, filename: String) -> Componen
         if let Some(class) = class {
             // Extract metadata from @Component decorator
             // Use implicit_standalone=true (v19+ default) since it doesn't affect URL extraction
-            if let Some(metadata) = extract_component_metadata(&allocator, class, true, &import_map)
+            if let Some(metadata) = extract_component_metadata(&allocator, class, true, &import_map, &source)
             {
                 // Collect template URL
                 if let Some(template_url) = &metadata.template_url {
@@ -1507,7 +1507,7 @@ pub fn extract_component_metadata_sync(
         if let Some(class) = class {
             // Extract metadata from @Component decorator
             if let Some(metadata) =
-                extract_component_metadata(&allocator, class, implicit_standalone, &import_map)
+                extract_component_metadata(&allocator, class, implicit_standalone, &import_map, &source)
             {
                 // Convert encapsulation to string
                 let encapsulation = match metadata.encapsulation {
@@ -1572,7 +1572,7 @@ pub fn extract_component_metadata_sync(
                 let animations = metadata.animations.as_ref().map(|e| emitter.emit_expression(e));
 
                 // Extract inputs from @Input decorators
-                let rust_inputs = extract_input_metadata(&allocator, class);
+                let rust_inputs = extract_input_metadata(&allocator, class, &source);
                 let inputs: Option<Vec<ExtractedInputMetadata>> = if rust_inputs.is_empty() {
                     None
                 } else {
@@ -1626,7 +1626,7 @@ pub fn extract_component_metadata_sync(
                 }
 
                 // Extract view queries from @ViewChild/@ViewChildren decorators
-                let rust_view_queries = extract_view_queries(&allocator, class);
+                let rust_view_queries = extract_view_queries(&allocator, class, &source);
                 let view_queries: Option<Vec<ExtractedQueryMetadata>> =
                     if rust_view_queries.is_empty() {
                         None
@@ -1647,7 +1647,7 @@ pub fn extract_component_metadata_sync(
                     };
 
                 // Extract content queries from @ContentChild/@ContentChildren decorators
-                let rust_content_queries = extract_content_queries(&allocator, class);
+                let rust_content_queries = extract_content_queries(&allocator, class, &source);
                 let queries: Option<Vec<ExtractedQueryMetadata>> =
                     if rust_content_queries.is_empty() {
                         None
@@ -1949,7 +1949,7 @@ pub fn compile_class_metadata_sync(
 
     // Build decorators array: [{ type: DecoratorClass, args: [...] }]
     let decorator_ref = decorator;
-    let decorators_expr = core_build_decorator_metadata_array(&allocator, &[decorator_ref]);
+    let decorators_expr = core_build_decorator_metadata_array(&allocator, &[decorator_ref], &source);
 
     // Build constructor parameters metadata
     // This standalone API doesn't have full transform pipeline context (constructor deps
@@ -1963,10 +1963,11 @@ pub fn compile_class_metadata_sync(
         None,
         &mut namespace_registry,
         &empty_import_map,
+        &source,
     );
 
     // Build property decorators metadata
-    let prop_decorators_expr = core_build_prop_decorators_metadata(&allocator, class);
+    let prop_decorators_expr = core_build_prop_decorators_metadata(&allocator, class, &source);
 
     // Create R3ClassMetadata
     let metadata = R3ClassMetadata {


### PR DESCRIPTION
## Summary

- Adds a `RawSource` variant to `OutputExpression` that holds original source text and emits it verbatim
- When `convert_oxc_expression` cannot fully convert an expression (e.g., `if` statements in arrow bodies, assignment expressions), it falls back to `RawSource` instead of silently dropping the expression
- Threads `source: &str` through all decorator extraction functions so the fallback has access to the original source text

This ensures any valid JavaScript in decorator properties (`providers`, `animations`, `viewProviders`, `useFactory`, etc.) is preserved in compiled output with 100% fidelity, regardless of whether the converter has a dedicated conversion arm.

## Test plan

- [x] 3 new unit tests for RawSource fallback behavior
- [x] 2 new integration tests (`test_use_factory_with_if_statement_preserved`, `test_providers_with_complex_expression_preserved`)
- [x] All 2,316 existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)