### PR TITLE
fix(compiler): use actual class declaration line number in debug info

### DIFF
--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -1649,6 +1649,7 @@ pub fn transform_angular_file(
                         template,
                         &mut metadata,
                         path,
+                        source,
                         options,
                         view_queries,
                         content_queries,
@@ -2315,6 +2316,7 @@ fn compile_component_full<'a>(
     template: &'a str,
     metadata: &mut ComponentMetadata<'a>,
     file_path: &str,
+    source: &str,
     options: &TransformOptions,
     view_queries: OxcVec<'a, R3QueryMetadata<'a>>,
     content_queries: OxcVec<'a, R3QueryMetadata<'a>>,
@@ -2589,13 +2591,22 @@ fn compile_component_full<'a>(
             allocator,
         ));
 
-        // Build the debug info
-        // Note: line_number is 1-indexed. We don't have access to the actual source
-        // line number here, but Angular uses the class declaration position.
-        // For now we use line 1, but this could be enhanced if we pass line info.
+        // Compute the 1-indexed line number of the class declaration from its byte offset
+        let class_line_number = {
+            let offset = metadata.class_span.start as usize;
+            let mut line = 1u32;
+            for &byte in &source.as_bytes()[..offset.min(source.len())] {
+                if byte == b'\n' {
+                    line += 1;
+                }
+            }
+            line
+        };
+
+        // Build the debug info with the actual class declaration line number
         let debug_info = R3ClassDebugInfo::new(component_type, metadata.class_name.clone())
             .with_file_path(Atom::from_in(file_path, allocator))
-            .with_line_number(1); // TODO: Get actual line number from class declaration
+            .with_line_number(class_line_number);
 
         // Compile to IIFE-wrapped expression
         let debug_info_expr = compile_class_debug_info(allocator, &debug_info);

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__component_with_inline_styles.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__component_with_inline_styles.snap
@@ -2,6 +2,7 @@
 source: crates/oxc_angular_compiler/tests/integration_test.rs
 expression: result.code
 ---
+
 import { Component } from '@angular/core';
 import * as i0 from '@angular/core';
 
@@ -21,5 +22,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:StyledComponent,select
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(StyledComponent,
-      {className:"StyledComponent",filePath:"styled.component.ts",lineNumber:1}));
+      {className:"StyledComponent",filePath:"styled.component.ts",lineNumber:9}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__component_with_multiple_styles.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__component_with_multiple_styles.snap
@@ -2,6 +2,7 @@
 source: crates/oxc_angular_compiler/tests/integration_test.rs
 expression: result.code
 ---
+
 import { Component } from '@angular/core';
 import * as i0 from '@angular/core';
 
@@ -20,5 +21,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:MultiStyledComponent,s
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(MultiStyledComponent,
-      {className:"MultiStyledComponent",filePath:"multi-styled.component.ts",lineNumber:1}));
+      {className:"MultiStyledComponent",filePath:"multi-styled.component.ts",lineNumber:12}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__component_without_styles.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__component_without_styles.snap
@@ -2,6 +2,7 @@
 source: crates/oxc_angular_compiler/tests/integration_test.rs
 expression: result.code
 ---
+
 import { Component } from '@angular/core';
 import * as i0 from '@angular/core';
 
@@ -20,5 +21,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:NoStylesComponent,sele
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(NoStylesComponent,
-      {className:"NoStylesComponent",filePath:"no-styles.component.ts",lineNumber:1}));
+      {className:"NoStylesComponent",filePath:"no-styles.component.ts",lineNumber:8}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__event_before_property_in_bindings.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__event_before_property_in_bindings.snap
@@ -2,6 +2,7 @@
 source: crates/oxc_angular_compiler/tests/integration_test.rs
 expression: result.code
 ---
+
 import { Component } from '@angular/core';
 import * as i0 from '@angular/core';
 
@@ -28,5 +29,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:TestComponent,selector
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(TestComponent,
-      {className:"TestComponent",filePath:"test.component.ts",lineNumber:1}));
+      {className:"TestComponent",filePath:"test.component.ts",lineNumber:9}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__host_directives_with_host_aliases.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__host_directives_with_host_aliases.snap
@@ -33,5 +33,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:MyComponent,selectors:
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(MyComponent,
-      {className:"MyComponent",filePath:"test.component.ts",lineNumber:1}));
+      {className:"MyComponent",filePath:"test.component.ts",lineNumber:22}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__host_directives_with_inputs_outputs.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__host_directives_with_inputs_outputs.snap
@@ -32,5 +32,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:MyComponent,selectors:
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(MyComponent,
-      {className:"MyComponent",filePath:"test.component.ts",lineNumber:1}));
+      {className:"MyComponent",filePath:"test.component.ts",lineNumber:22}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__ngfor_attribute_ordering.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__ngfor_attribute_ordering.snap
@@ -2,6 +2,7 @@
 source: crates/oxc_angular_compiler/tests/integration_test.rs
 expression: result.code
 ---
+
 import { Component } from '@angular/core';
 import * as i0 from '@angular/core';
 
@@ -33,5 +34,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:TestComponent,selector
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(TestComponent,
-      {className:"TestComponent",filePath:"test.component.ts",lineNumber:1}));
+      {className:"TestComponent",filePath:"test.component.ts",lineNumber:9}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__selector_attrs_const_emission.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__selector_attrs_const_emission.snap
@@ -24,5 +24,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:BadgeComponent,selecto
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(BadgeComponent,
-      {className:"BadgeComponent",filePath:"badge.component.ts",lineNumber:1}));
+      {className:"BadgeComponent",filePath:"badge.component.ts",lineNumber:9}));
 })();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__standalone_component_uses_full_mode.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__standalone_component_uses_full_mode.snap
@@ -2,6 +2,7 @@
 source: crates/oxc_angular_compiler/tests/integration_test.rs
 expression: result.code
 ---
+
 import { Component } from '@angular/core';
 import * as i0 from '@angular/core';
 
@@ -46,5 +47,5 @@ static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({type:ExternalComponent,sele
 }
 (() =>{
   (((typeof ngDevMode === "undefined") || ngDevMode) && i0.ɵsetClassDebugInfo(ExternalComponent,
-      {className:"ExternalComponent",filePath:"test.component.ts",lineNumber:1}));
+      {className:"ExternalComponent",filePath:"test.component.ts",lineNumber:9}));
 })();


### PR DESCRIPTION
The `ɵsetClassDebugInfo` call was hardcoding `lineNumber: 1` for all components. This was noted as a TODO in the codebase.

The fix threads the source text into `compile_component_full` and computes the actual 1-indexed line number from `metadata.class_span.start`.

Snapshot updates reflect the corrected line numbers (e.g. `lineNumber:9`, `lineNumber:12`, `lineNumber:22`). A few snapshots also picked up a minor formatting normalization from `insta` (blank line after the `---` header) — no functional change.
