### PR TITLE
chore: add typos.toml configuration

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,34 @@
+[files]
+extend-exclude = [
+  # Conformance fixtures are extracted from Angular's TypeScript specs
+  "crates/angular_conformance/fixtures/",
+  # HTML entities are spec-defined names, not English words
+  "crates/oxc_angular_compiler/src/parser/html/entities.rs",
+  # E2E comparison fixtures contain CSS/HTML test strings
+  "napi/angular-compiler/e2e/",
+]
+
+[default.extend-words]
+# IIFE = Immediately Invoked Function Expression (standard JS term)
+IIFEs = "IIFEs"
+IIF = "IIF"
+# Jasmine disabled test markers
+xdescribe = "xdescribe"
+xit = "xit"
+# Variable name for PrefixNot
+pn = "pn"
+# "mis-select" is intentional in comments
+mis = "mis"
+# German i18n test data
+alle = "alle"
+Sie = "Sie"
+ein = "ein"
+Elemente = "Elemente"
+# Angular template test data: "d.ot" is a dotted property binding
+ot = "ot"
+# "mergable" used in original Angular source comment
+mergable = "mergable"
+
+[default.extend-identifiers]
+# HTML entity names (spec-defined)
+becaus = "becaus"


### PR DESCRIPTION
The `Justfile` runs `typos` as part of `just ready`, but no `typos.toml` config exists. This causes `typos` to exit with code 2 on ~40+ false positives, aborting the `just ready` workflow for every contributor.

This adds a `typos.toml` that suppresses the false positives:
- Excludes conformance fixtures (extracted from Angular's own specs, typos are upstream)
- Excludes HTML entity table (`entities.rs` — spec-defined names like `becaus`, `infintie`)
- Excludes e2e comparison fixtures (CSS/HTML test strings)
- Allows standard JS/TS terms (`IIFE`, `xdescribe`, `xit`)
- Allows German i18n test data (`Sie`, `ein`, `Elemente`, `alle`)
- Allows Angular-specific identifiers and comments (`d.ot` property binding, `mergable` from upstream source)

Note: CI does not run `typos`, so this is purely a local developer experience improvement.
