### PR TITLE
fix(compiler): remove type-only exports

### DIFF
--- a/crates/oxc_angular_compiler/src/component/import_elision.rs
+++ b/crates/oxc_angular_compiler/src/component/import_elision.rs
@@ -2105,16 +2105,8 @@ import { Foo, Bar } from './types';
 export type { Foo, Bar };
 "#;
         let filtered = filter_source(source);
-        assert!(
-            !filtered.contains("Foo"),
-            "Foo should be removed.\nFiltered:\n{}",
-            filtered
-        );
-        assert!(
-            !filtered.contains("Bar"),
-            "Bar should be removed.\nFiltered:\n{}",
-            filtered
-        );
+        assert!(!filtered.contains("Foo"), "Foo should be removed.\nFiltered:\n{}", filtered);
+        assert!(!filtered.contains("Bar"), "Bar should be removed.\nFiltered:\n{}", filtered);
     }
 
     #[test]


### PR DESCRIPTION
```ts
import { Config } from './config';
export type { Config };
```
was transformed to
```js
export type { Config };
```
and was causing problems as `Config` is not declared in the file.
