### PR TITLE
feat: add attribute, input, and output visitor methods to R3Visitor

### DIFF
--- a/crates/oxc_angular_compiler/src/ast/r3.rs
+++ b/crates/oxc_angular_compiler/src/ast/r3.rs
@@ -1607,3 +1607,125 @@ pub struct R3ParseResult<'a> {
     /// Comment nodes (if collected).
     pub comment_nodes: Option<Vec<'a, R3Comment<'a>>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+
+    use crate::ast::r3::{R3Visitor, visit_all};
+    use crate::parser::html::HtmlParser;
+    use crate::transform::html_to_r3::{TransformOptions, html_ast_to_r3_ast};
+
+    /// A visitor that collects names of visited attributes, inputs, and outputs.
+    struct AttributeCollector {
+        text_attributes: Vec<String>,
+        bound_attributes: Vec<String>,
+        bound_events: Vec<String>,
+        elements: Vec<String>,
+    }
+
+    impl AttributeCollector {
+        fn new() -> Self {
+            Self {
+                text_attributes: Vec::new(),
+                bound_attributes: Vec::new(),
+                bound_events: Vec::new(),
+                elements: Vec::new(),
+            }
+        }
+    }
+
+    impl<'a> R3Visitor<'a> for AttributeCollector {
+        fn visit_element(&mut self, element: &super::R3Element<'a>) {
+            self.elements.push(element.name.to_string());
+            self.visit_element_children(element);
+        }
+
+        fn visit_text_attribute(&mut self, attr: &super::R3TextAttribute<'a>) {
+            self.text_attributes.push(attr.name.to_string());
+        }
+
+        fn visit_bound_attribute(&mut self, attr: &super::R3BoundAttribute<'a>) {
+            self.bound_attributes.push(attr.name.to_string());
+        }
+
+        fn visit_bound_event(&mut self, event: &super::R3BoundEvent<'a>) {
+            self.bound_events.push(event.name.to_string());
+        }
+    }
+
+    #[test]
+    fn test_r3_visitor_visits_attributes_inputs_outputs() {
+        let allocator = Allocator::default();
+        let template =
+            r#"<button type="submit" [disabled]="isDisabled" (click)="onClick()">Save</button>"#;
+
+        let html_result = HtmlParser::new(&allocator, template, "test.html").parse();
+        assert!(html_result.errors.is_empty());
+
+        let r3_result = html_ast_to_r3_ast(
+            &allocator,
+            template,
+            &html_result.nodes,
+            TransformOptions::default(),
+        );
+        assert!(r3_result.errors.is_empty());
+
+        let mut collector = AttributeCollector::new();
+        visit_all(&mut collector, &r3_result.nodes);
+
+        assert_eq!(collector.elements, vec!["button"]);
+        assert_eq!(collector.text_attributes, vec!["type"]);
+        assert_eq!(collector.bound_attributes, vec!["disabled"]);
+        assert_eq!(collector.bound_events, vec!["click"]);
+    }
+
+    #[test]
+    fn test_r3_visitor_visits_nested_elements() {
+        let allocator = Allocator::default();
+        let template = r#"<div id="outer"><span class="inner" [title]="t" (mouseenter)="onHover()">text</span></div>"#;
+
+        let html_result = HtmlParser::new(&allocator, template, "test.html").parse();
+        assert!(html_result.errors.is_empty());
+
+        let r3_result = html_ast_to_r3_ast(
+            &allocator,
+            template,
+            &html_result.nodes,
+            TransformOptions::default(),
+        );
+        assert!(r3_result.errors.is_empty());
+
+        let mut collector = AttributeCollector::new();
+        visit_all(&mut collector, &r3_result.nodes);
+
+        assert_eq!(collector.elements, vec!["div", "span"]);
+        assert_eq!(collector.text_attributes, vec!["id", "class"]);
+        assert_eq!(collector.bound_attributes, vec!["title"]);
+        assert_eq!(collector.bound_events, vec!["mouseenter"]);
+    }
+
+    #[test]
+    fn test_r3_visitor_default_noop_does_not_break() {
+        let allocator = Allocator::default();
+        let template = r#"<input [value]="name" (change)="update()" required />"#;
+
+        let html_result = HtmlParser::new(&allocator, template, "test.html").parse();
+        assert!(html_result.errors.is_empty());
+
+        let r3_result = html_ast_to_r3_ast(
+            &allocator,
+            template,
+            &html_result.nodes,
+            TransformOptions::default(),
+        );
+        assert!(r3_result.errors.is_empty());
+
+        // A visitor with all default no-op methods should traverse without panic
+        struct NoopVisitor;
+        impl<'a> R3Visitor<'a> for NoopVisitor {}
+
+        let mut visitor = NoopVisitor;
+        visit_all(&mut visitor, &r3_result.nodes);
+    }
+}


### PR DESCRIPTION
Adds `visit_text_attribute`, `visit_bound_attribute`, and `visit_bound_event` methods to the `R3Visitor` trait, and updates the default traversal for elements, templates, components, and content nodes to call them.

Previously, `visit_element_children` and `visit_template_children` only traversed child nodes, skipping over `attributes`, `inputs`, and `outputs`. This made it impossible to use the visitor pattern to inspect bindings and events without overriding the element visitor and manually iterating those fields.

This is a non-breaking change — all new methods have default no-op implementations, so existing `R3Visitor` implementations continue to work unchanged.

**Motivation:** enables using `R3Visitor` for template linting use cases, where rules need to inspect attributes and bindings (e.g. checking for `[property]` bindings, `(event)` handlers, or static attribute values).
