### PR TITLE
fix: preserve multi-byte UTF-8 characters in CSS encapsulation

### DIFF
--- a/crates/oxc_angular_compiler/src/styles/encapsulation.rs
+++ b/crates/oxc_angular_compiler/src/styles/encapsulation.rs
@@ -33,6 +33,28 @@ const COMMENT_PLACEHOLDER: &str = "%COMMENT%";
 const POLYFILL_HOST: &str = "-shadowcsshost";
 const POLYFILL_HOST_NO_COMBINATOR: &str = "-shadowcsshost-no-combinator";
 
+/// Push a single UTF-8 character starting at byte position `i` from `source` into `result`.
+/// Returns the number of bytes consumed (1 for ASCII, 2-4 for multi-byte).
+///
+/// This replaces the incorrect `result.push(bytes[i] as char)` pattern which
+/// corrupts multi-byte UTF-8 characters by treating each byte as a Latin-1 codepoint.
+#[inline]
+fn push_utf8_char(result: &mut String, source: &str, i: usize) -> usize {
+    // Determine UTF-8 character width from the leading byte per RFC 3629.
+    let b = source.as_bytes()[i];
+    let width = if b < 0x80 {
+        1
+    } else if b < 0xE0 {
+        2
+    } else if b < 0xF0 {
+        3
+    } else {
+        4
+    };
+    result.push_str(&source[i..i + width]);
+    width
+}
+
 // =============================================================================
 // SafeSelector - Escapes problematic CSS patterns before processing
 // =============================================================================
@@ -101,8 +123,7 @@ impl SafeSelector {
                         i += 1;
                     }
                 } else {
-                    new_result.push(bytes[i] as char);
-                    i += 1;
+                    i += push_utf8_char(&mut new_result, &result, i);
                 }
             }
             result = new_result;
@@ -125,8 +146,7 @@ impl SafeSelector {
                     new_result.push_str(&placeholder);
                     i += 2;
                 } else {
-                    new_result.push(bytes[i] as char);
-                    i += 1;
+                    i += push_utf8_char(&mut new_result, &result, i);
                 }
             }
             result = new_result;
@@ -349,8 +369,7 @@ fn extract_comments(css: &str) -> (String, Vec<String>) {
 
             result.push_str(COMMENT_PLACEHOLDER);
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            i += push_utf8_char(&mut result, css, i);
         }
     }
 
@@ -505,8 +524,7 @@ fn scope_keyframes_names(
                         (name, name_end, None)
                     } else {
                         // No valid name found
-                        result.push(bytes[i] as char);
-                        i += 1;
+                        i += push_utf8_char(&mut result, css, i);
                         continue;
                     };
 
@@ -571,8 +589,7 @@ fn scope_keyframes_names(
             }
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, css, i);
     }
 
     result
@@ -627,8 +644,7 @@ fn scope_animation_rules(
                     || !css.is_char_boundary(i + value_start)
                     || !css.is_char_boundary(i + value_end)
                 {
-                    result.push(bytes[i] as char);
-                    i += 1;
+                    i += push_utf8_char(&mut result, css, i);
                     continue;
                 }
                 let prefix = &css[i..i + prefix_end];
@@ -655,8 +671,7 @@ fn scope_animation_rules(
             }
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, css, i);
     }
 
     result
@@ -2581,8 +2596,7 @@ fn replace_host_context_patterns(s: &str, replacement: &str) -> String {
             i = after;
             continue;
         }
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, s, i);
     }
 
     result
@@ -2640,8 +2654,7 @@ fn insert_polyfill_directives(css: &str) -> String {
                 continue;
             }
         }
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, css, i);
     }
 
     result
@@ -2762,8 +2775,7 @@ fn insert_polyfill_rules(css: &str) -> String {
                 }
             }
         }
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, css, i);
     }
 
     result
@@ -3048,8 +3060,7 @@ fn strip_deep_combinators(s: &str) -> String {
             continue;
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, s, i);
     }
 
     result
@@ -3097,8 +3108,7 @@ fn strip_host_patterns(s: &str) -> String {
             continue;
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, s, i);
     }
 
     result
@@ -3147,8 +3157,7 @@ fn remove_unscoped_rules(css: &str) -> String {
                 continue;
             }
         }
-        result.push(bytes[i] as char);
-        i += 1;
+        i += push_utf8_char(&mut result, css, i);
     }
 
     result

--- a/crates/oxc_angular_compiler/tests/shadow_css_test.rs
+++ b/crates/oxc_angular_compiler/tests/shadow_css_test.rs
@@ -290,6 +290,56 @@ fn test_handle_curly_braces_in_quoted_content() {
     assert_css_eq!(shim(css, "contenta"), expected);
 }
 
+#[test]
+fn test_unicode_in_content_property() {
+    // Issue #191: unicode characters in :after CSS content property
+    // Raw CSS escape sequence (as from inline styles)
+    let css = r".test-div:after { content: '\2022'; }";
+    assert_css_eq!(shim(css, "contenta"), r".test-div[contenta]:after { content: '\2022'; }");
+
+    // After Sass compilation - Sass converts \2022 to actual bullet char
+    let css = ".test-div:after { content: \"\u{2022}\"; }";
+    assert_css_eq!(shim(css, "contenta"), ".test-div[contenta]:after { content:\"\u{2022}\"; }");
+}
+
+#[test]
+fn test_multibyte_utf8_preserved_in_css_values() {
+    // Various multi-byte UTF-8 characters in CSS content property
+    // 2-byte: ¢ (U+00A2), © (U+00A9)
+    let css = ".a:after { content: \"\u{00A2}\u{00A9}\"; }";
+    let result = shim(css, "contenta");
+    assert!(result.contains("\u{00A2}\u{00A9}"), "2-byte UTF-8 chars corrupted: {result}");
+
+    // 3-byte: • (U+2022), — (U+2014), → (U+2192)
+    let css = ".a:after { content: \"\u{2022}\u{2014}\u{2192}\"; }";
+    let result = shim(css, "contenta");
+    assert!(result.contains("\u{2022}\u{2014}\u{2192}"), "3-byte UTF-8 chars corrupted: {result}");
+
+    // 4-byte: 😀 (U+1F600)
+    let css = ".a:after { content: \"\u{1F600}\"; }";
+    let result = shim(css, "contenta");
+    assert!(result.contains('\u{1F600}'), "4-byte UTF-8 char corrupted: {result}");
+
+    // Non-ASCII in selector (e.g. class name with accented chars)
+    let css = ".caf\u{00E9} { color: red; }";
+    let result = shim(css, "contenta");
+    assert!(result.contains("caf\u{00E9}"), "Non-ASCII in selector corrupted: {result}");
+}
+
+#[test]
+fn test_finalize_preserves_unicode() {
+    use oxc_angular_compiler::styles::finalize_component_style;
+    // Full pipeline with Sass-compiled CSS containing actual bullet character
+    let css = ".test:after { content: \"\u{2022}\"; }";
+    let result = finalize_component_style(css, true, "_ngcontent-%COMP%", "_nghost-%COMP%", true);
+    assert!(result.contains('\u{2022}'), "Bullet lost in full pipeline: {result}");
+
+    // With @charset prefix from Sass
+    let css = "@charset \"UTF-8\";\n.test:after { content: \"\u{2022}\"; }";
+    let result = finalize_component_style(css, true, "_ngcontent-%COMP%", "_nghost-%COMP%", true);
+    assert!(result.contains('\u{2022}'), "Bullet lost with @charset: {result}");
+}
+
 // ============================================================================
 // Playground CSS Test (real-world case)
 // ============================================================================


### PR DESCRIPTION
The CSS encapsulation code used `bytes[i] as char` to copy characters,
which treats each byte of a multi-byte UTF-8 sequence as a separate
Latin-1 codepoint. This corrupted non-ASCII characters (e.g. bullet •)
that appear after Sass compiles CSS escape sequences like `\2022`.

Replace all 13 instances with `push_utf8_char()` which reads the UTF-8
character width from the leading byte and copies the full character.

- Close https://github.com/voidzero-dev/oxc-angular-compiler/issues/191

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are a targeted replacement of byte-to-char copying with a UTF-8-safe helper and are covered by added Unicode-focused tests.
> 
> **Overview**
> Fixes Unicode corruption in the CSS encapsulation pipeline by replacing multiple `bytes[i] as char` code paths with a shared `push_utf8_char()` helper that copies full UTF-8 characters when scanning and rewriting CSS.
> 
> Adds regression tests ensuring non-ASCII characters (including 2/3/4-byte codepoints) are preserved in `content` values, selectors, and through `finalize_component_style` (including with an `@charset "UTF-8";` prefix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae685c7bba333849e1cfeb65c1d0da0152660b89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->