### PR TITLE
fix(injectable): don't default providedIn to 'root' when not specified

### DIFF
--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -4316,10 +4316,10 @@ export class LocalService {}
             result.code.contains("ɵɵdefineInjectable"),
             "Code should contain ɵɵdefineInjectable"
         );
-        // Should default to providedIn: "root" (Angular's default behavior)
+        // Should NOT have providedIn when not explicitly specified
         assert!(
-            result.code.contains(r#"providedIn:"root""#),
-            "Code should contain providedIn:\"root\" by default, but got:\n{}",
+            !result.code.contains("providedIn"),
+            "Code should NOT contain providedIn when not specified, but got:\n{}",
             result.code
         );
     }

--- a/crates/oxc_angular_compiler/src/injectable/decorator.rs
+++ b/crates/oxc_angular_compiler/src/injectable/decorator.rs
@@ -230,12 +230,12 @@ pub fn extract_injectable_metadata<'a>(
         _ => return None,
     };
 
-    // If no arguments, return basic metadata with default providedIn: 'root'
+    // If no arguments, return basic metadata with no providedIn
     if call_expr.arguments.is_empty() {
         return Some(InjectableMetadata {
             class_name,
             class_span,
-            provided_in: Some(ProvidedInValue::Root),
+            provided_in: None,
             use_class: None,
             use_factory: None,
             use_value: None,
@@ -250,8 +250,8 @@ pub fn extract_injectable_metadata<'a>(
         _ => return None,
     };
 
-    // Extract providedIn (default to 'root' if not specified)
-    let provided_in = extract_provided_in(allocator, config_obj).or(Some(ProvidedInValue::Root));
+    // Extract providedIn (None if not specified)
+    let provided_in = extract_provided_in(allocator, config_obj);
 
     // Extract useClass
     let use_class = extract_use_class(allocator, config_obj);
@@ -681,8 +681,8 @@ mod tests {
         assert!(metadata.is_some());
         let metadata = metadata.unwrap();
         assert_eq!(metadata.class_name.as_str(), "MyService");
-        // Default to 'root' when not specified (Angular's default behavior)
-        assert!(matches!(metadata.provided_in, Some(ProvidedInValue::Root)));
+        // No providedIn when not specified
+        assert!(metadata.provided_in.is_none());
     }
 
     #[test]
@@ -715,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_extract_injectable_with_empty_object() {
-        // @Injectable({}) should default to providedIn: 'root'
+        // @Injectable({}) should have no providedIn
         let allocator = Allocator::default();
         let source = r#"
             @Injectable({})
@@ -726,8 +726,8 @@ mod tests {
         assert!(metadata.is_some());
         let metadata = metadata.unwrap();
         assert_eq!(metadata.class_name.as_str(), "MyService");
-        // Default to 'root' when providedIn is not specified in the object
-        assert!(matches!(metadata.provided_in, Some(ProvidedInValue::Root)));
+        // No providedIn when not specified in the object
+        assert!(metadata.provided_in.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `@Injectable()` and `@Injectable({})` no longer incorrectly default `providedIn` to `'root'`
- When `providedIn` is not explicitly specified, it is now omitted entirely, matching Angular's actual compiler behavior
- Confirmed by the official Angular compliance tests (e.g. `injectable_factory.ts` expects no `providedIn` field in output)

## Test plan

- [x] Updated unit tests in `decorator.rs` to assert `provided_in.is_none()` for bare `@Injectable()` and `@Injectable({})`
- [x] Updated integration test in `transform.rs` to verify `providedIn` is absent in compiled output
- [x] All 2,303 tests pass (including 987 compliance tests)