### PR TITLE
fix(angular): emit ɵɵControlFeature from linker for controlCreate metadata

### DIFF
--- a/crates/oxc_angular_compiler/src/linker/mod.rs
+++ b/crates/oxc_angular_compiler/src/linker/mod.rs
@@ -1630,7 +1630,8 @@ fn build_queries(
 /// - `hostDirectives: [...]` → `ns.ɵɵHostDirectivesFeature([...])`
 /// - `usesInheritance: true` → `ns.ɵɵInheritDefinitionFeature`
 /// - `usesOnChanges: true` → `ns.ɵɵNgOnChangesFeature`
-/// Order is important: ProvidersFeature → HostDirectivesFeature → InheritDefinitionFeature → NgOnChangesFeature
+/// - `controlCreate: { passThroughInput }` → `ns.ɵɵControlFeature(passThroughInput)`
+/// Order is important: ProvidersFeature → HostDirectivesFeature → InheritDefinitionFeature → NgOnChangesFeature → ControlFeature
 /// (see packages/compiler/src/render3/view/compiler.ts:119-161)
 fn build_features(meta: &ObjectExpression<'_>, source: &str, ns: &str) -> Option<String> {
     let mut features: Vec<String> = Vec::new();
@@ -1664,6 +1665,17 @@ fn build_features(meta: &ObjectExpression<'_>, source: &str, ns: &str) -> Option
     // 4. NgOnChangesFeature
     if get_bool_property(meta, "usesOnChanges") == Some(true) {
         features.push(format!("{ns}.\u{0275}\u{0275}NgOnChangesFeature"));
+    }
+
+    // 5. ControlFeature — for signal form directives declaring controlCreate
+    //    `controlCreate: { passThroughInput: "formField" | null }`
+    //    emits `ɵɵControlFeature("formField")` or `ɵɵControlFeature(null)`
+    if let Some(control_create) = get_object_property(meta, "controlCreate") {
+        let pass_through = match get_string_property(control_create, "passThroughInput") {
+            Some(s) => format!("\"{s}\""),
+            None => "null".to_string(),
+        };
+        features.push(format!("{ns}.\u{0275}\u{0275}ControlFeature({pass_through})"));
     }
 
     if features.is_empty() { None } else { Some(format!("[{}]", features.join(", "))) }

--- a/crates/oxc_angular_compiler/tests/linker_test.rs
+++ b/crates/oxc_angular_compiler/tests/linker_test.rs
@@ -95,3 +95,29 @@ fn test_link_inputs_array_format_with_transform_function() {
     let result = link(&allocator, &code, "test.mjs");
     insta::assert_snapshot!(result.code);
 }
+
+/// Regression: signal form FormField directive declares
+/// `controlCreate: { passThroughInput: "formField" }` in its partial metadata.
+/// The linker must emit `ɵɵControlFeature("formField")` in the features array,
+/// otherwise `DirectiveDef.controlDef` is never set and the runtime
+/// `ɵɵcontrolCreate()` / `ɵɵcontrol()` instructions become no-ops.
+/// See voidzero-dev/oxc-angular-compiler#229.
+#[test]
+fn test_link_control_feature_pass_through_input() {
+    let allocator = Allocator::default();
+    let code = r#"import * as i0 from "@angular/core";
+export class FormField {}
+FormField.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "21.2.8", type: FormField, selector: "[formField]", inputs: { field: { classPropertyName: "field", publicName: "formField", isRequired: true, isSignal: true } }, controlCreate: { passThroughInput: "formField" }, isStandalone: true, isSignal: true });"#;
+    let result = link(&allocator, code, "test.mjs");
+    insta::assert_snapshot!(result.code);
+}
+
+#[test]
+fn test_link_control_feature_null_pass_through_input() {
+    let allocator = Allocator::default();
+    let code = r#"import * as i0 from "@angular/core";
+export class MyControl {}
+MyControl.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "21.2.8", type: MyControl, selector: "[myControl]", controlCreate: { passThroughInput: null }, isStandalone: true, isSignal: true });"#;
+    let result = link(&allocator, code, "test.mjs");
+    insta::assert_snapshot!(result.code);
+}

--- a/crates/oxc_angular_compiler/tests/snapshots/linker_test__link_control_feature_null_pass_through_input.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/linker_test__link_control_feature_null_pass_through_input.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxc_angular_compiler/tests/linker_test.rs
+expression: result.code
+---
+import * as i0 from "@angular/core";
+export class MyControl {}
+MyControl.ɵdir = i0.ɵɵdefineDirective({ type: MyControl, selectors: [["", "myControl", ""]], signals: true, features: [i0.ɵɵControlFeature(null)] });

--- a/crates/oxc_angular_compiler/tests/snapshots/linker_test__link_control_feature_pass_through_input.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/linker_test__link_control_feature_pass_through_input.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxc_angular_compiler/tests/linker_test.rs
+expression: result.code
+---
+import * as i0 from "@angular/core";
+export class FormField {}
+FormField.ɵdir = i0.ɵɵdefineDirective({ type: FormField, selectors: [["", "formField", ""]], inputs: { field: [1, "formField", "field"] }, signals: true, features: [i0.ɵɵControlFeature("formField")] });

--- a/napi/angular-compiler/e2e/compare/fixtures/regressions/formfield-alias.fixture.ts
+++ b/napi/angular-compiler/e2e/compare/fixtures/regressions/formfield-alias.fixture.ts
@@ -1,0 +1,32 @@
+import type { Fixture } from '../types.js'
+
+export const fixtures: Fixture[] = [
+  {
+    name: 'formfield-alias-repro',
+    category: 'regressions',
+    description: 'Issue #229 repro: [formField] binding with aliased field input',
+    className: 'AppComponent',
+    type: 'full-transform',
+    sourceCode: `
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { form, FormField, required } from '@angular/forms/signals';
+
+@Component({
+  selector: 'app-root',
+  imports: [FormField],
+  template: \`<input type="text" [formField]="myForm.firstName" />\`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppComponent {
+  protected readonly myFormModel = signal({
+    firstName: 'Foo',
+    email: 'foo@bar.com',
+  });
+  protected readonly myForm = form(this.myFormModel, path => {
+    required(path.firstName);
+  });
+}
+`.trim(),
+    expectedFeatures: ['ɵɵproperty', 'ɵɵcontrol', 'ɵɵcontrolCreate'],
+  },
+]


### PR DESCRIPTION
The Angular Linker's build_features was ignoring the controlCreate property
on ɵɵngDeclareDirective, so directives like @angular/forms/signals FormField
were linked without ɵɵControlFeature(passThroughInput). This left
DirectiveDef.controlDef unset at runtime, making template-emitted
ɵɵcontrolCreate()/ɵɵcontrol() calls no-ops and breaking [formField] bindings
with NG0950. Mirrors Angular TS compiler.ts:151-155.

Fixes voidzero-dev/oxc-angular-compiler#229

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to feature emission for a specific metadata field, with added regression tests reducing the chance of unintended output changes.
> 
> **Overview**
> Fixes the linker’s `build_features` to recognize `controlCreate` in directive/component partial metadata and append `ns.ɵɵControlFeature(passThroughInput)` (string or `null`) to the generated `features` array in the correct order.
> 
> Adds regression coverage via new snapshot tests for both pass-through and `null` cases, plus an e2e fixture reproducing the `[formField]` alias binding issue from #229.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a00ccad04478aa14f510ed65628c3d312aaa573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->