### PR TITLE
ci: replace actions/checkout with taiki-e/checkout-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -69,9 +70,10 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -104,9 +106,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: napi-smoke
     steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,10 @@ jobs:
       - name: Support longpaths
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --system core.longpaths true
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
 
       - name: Print rustup toolchain version
         shell: bash
@@ -124,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0


### PR DESCRIPTION
## Summary
- replace `actions/checkout` with `taiki-e/checkout-action` pinned to `v1.4.2`
- keep submodule checkout behavior with explicit `git submodule update --init --recursive`

## Verification
- `actionlint`
