### PR TITLE
ci: fix musl release builds by bumping taiki-e/install-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           version: 0.15.2
 
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@ffdab026038b43b56c3c9540cdadb98181c6155c # v2.27.8
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         if: ${{ contains(matrix.target, 'musl') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

The last few releases seem to have been failing: https://github.com/voidzero-dev/oxc-angular-compiler/actions/runs/25418129497/job/74553825172

- The release workflow's two musl matrix jobs (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) fail at the `Install cargo-zigbuild` step. Verified against [run 25418129497](https://github.com/voidzero-dev/oxc-angular-compiler/actions/runs/25418129497).
- Root cause: `taiki-e/install-action@v2.27.8` has no native manifest for `cargo-zigbuild` and falls back to `cargo-binstall@1.6.3`, whose old TOML parser rejects `edition = "2024"` in the current `cargo-zigbuild` `Cargo.toml`.
- Bumping to `v2.77.1` ships a native `cargo-zigbuild` manifest that downloads the prebuilt binary directly from the `rust-cross/cargo-zigbuild` GitHub release, bypassing `cargo-binstall` entirely.

While I have not been able to verify this, I believe this should resolve the issue.