### PR TITLE
fix(import_elision): handle tuple type elements without panicking

### DIFF
--- a/crates/oxc_angular_compiler/src/component/import_elision.rs
+++ b/crates/oxc_angular_compiler/src/component/import_elision.rs
@@ -235,8 +235,51 @@ impl<'a> ImportElisionAnalyzer<'a> {
                 Self::collect_computed_keys_from_ts_type(&array_type.element_type, result);
             }
             TSType::TSTupleType(tuple_type) => {
+                // `TSTupleElement` inherits the full set of `TSType`
+                // variants AND adds three of its own: `TSOptionalType`
+                // (`[number?]`), `TSRestType` (`[...string[]]`), and
+                // `TSNamedTupleMember` (`[name: string]`). The previous
+                // `element.to_ts_type()` call panicked with
+                // `Option::unwrap() on a None value` whenever a tuple
+                // contained any of those three variants — common in
+                // real code, e.g. function signatures expressed as
+                // tuple types in component decorator metadata.
+                //
+                // Use `as_ts_type()` (the safe `Option`-returning
+                // sibling of `to_ts_type`) for inherited variants, and
+                // unpack the wrapped type for each of the three named
+                // variants explicitly.
                 for element in &tuple_type.element_types {
-                    Self::collect_computed_keys_from_ts_type(element.to_ts_type(), result);
+                    if let Some(ty) = element.as_ts_type() {
+                        Self::collect_computed_keys_from_ts_type(ty, result);
+                        continue;
+                    }
+                    match element {
+                        oxc_ast::ast::TSTupleElement::TSOptionalType(opt) => {
+                            Self::collect_computed_keys_from_ts_type(
+                                &opt.type_annotation,
+                                result,
+                            );
+                        }
+                        oxc_ast::ast::TSTupleElement::TSRestType(rest) => {
+                            Self::collect_computed_keys_from_ts_type(
+                                &rest.type_annotation,
+                                result,
+                            );
+                        }
+                        oxc_ast::ast::TSTupleElement::TSNamedTupleMember(named) => {
+                            // `named.element_type` is itself a
+                            // `TSTupleElement`; recurse into its
+                            // inherited TSType (named members
+                            // can't nest per the TS spec, so we
+                            // only need the inherited-variant
+                            // branch here).
+                            if let Some(inner) = named.element_type.as_ts_type() {
+                                Self::collect_computed_keys_from_ts_type(inner, result);
+                            }
+                        }
+                        _ => {}
+                    }
                 }
             }
             TSType::TSTypeReference(type_ref) => {
@@ -244,6 +287,15 @@ impl<'a> ImportElisionAnalyzer<'a> {
                     for ty in &type_args.params {
                         Self::collect_computed_keys_from_ts_type(ty, result);
                     }
+                }
+            }
+            TSType::TSNamedTupleMember(named) => {
+                // Named tuple members (`[label: T]`) are inherited TSType variants,
+                // so they reach here via the `as_ts_type()` branch in the TSTupleType
+                // handler. The unreachable match arm added there is a no-op; traversal
+                // must happen here instead.
+                if let Some(inner) = named.element_type.as_ts_type() {
+                    Self::collect_computed_keys_from_ts_type(inner, result);
                 }
             }
             TSType::TSParenthesizedType(paren_type) => {
@@ -1958,6 +2010,83 @@ class MyComponent {
             !type_only.contains("myKey"),
             "myKey in tuple element type literal should be preserved"
         );
+    }
+
+    #[test]
+    fn test_computed_key_in_optional_tuple_element_preserved() {
+        // TSOptionalType (`[number?]`) in a tuple previously caused a panic via
+        // `to_ts_type()` (which called `unwrap()` on None). The fix uses
+        // `as_ts_type()` and handles the three named TSTupleElement variants.
+        let source = r#"
+import { Component, Input } from '@angular/core';
+import { myKey } from './keys';
+
+@Component({ selector: 'test' })
+class MyComponent {
+    @Input() pair: [string?, { [myKey]: number }?];
+}
+"#;
+        let type_only = analyze_source(source);
+        assert!(
+            !type_only.contains("myKey"),
+            "myKey in optional tuple element type literal should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_computed_key_in_rest_tuple_element_preserved() {
+        // TSRestType (`[...T[]]`) in a tuple previously caused a panic via
+        // `to_ts_type()`. The fix explicitly unwraps `TSRestType`.
+        let source = r#"
+import { Component, Input } from '@angular/core';
+import { myKey } from './keys';
+
+@Component({ selector: 'test' })
+class MyComponent {
+    @Input() pair: [string, ...{ [myKey]: number }[]];
+}
+"#;
+        let type_only = analyze_source(source);
+        assert!(
+            !type_only.contains("myKey"),
+            "myKey inside rest tuple element type should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_computed_key_in_named_tuple_member_preserved() {
+        // TSNamedTupleMember (`[name: T]`) in a tuple previously caused a panic
+        // via `to_ts_type()`. The fix explicitly unwraps `TSNamedTupleMember`.
+        let source = r#"
+import { Component, Input } from '@angular/core';
+import { myKey } from './keys';
+
+@Component({ selector: 'test' })
+class MyComponent {
+    @Input() pair: [label: string, item: { [myKey]: number }];
+}
+"#;
+        let type_only = analyze_source(source);
+        assert!(
+            !type_only.contains("myKey"),
+            "myKey in named tuple member type literal should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_tuple_with_mixed_element_kinds_no_panic() {
+        // Regression: a tuple with optional, rest, and named members together
+        // must not panic (TSOptionalType/TSRestType previously hit the unwrap in to_ts_type).
+        let source = r#"
+import { Component, Input } from '@angular/core';
+
+@Component({ selector: 'test' })
+class MyComponent {
+    @Input() data: [label: string, value?: number, ...rest: string[]];
+}
+"#;
+        let type_only = analyze_source(source);
+        assert!(!type_only.contains("Component"), "Component should be preserved (decorator)");
     }
 
     #[test]

--- a/crates/oxc_angular_compiler/src/component/import_elision.rs
+++ b/crates/oxc_angular_compiler/src/component/import_elision.rs
@@ -245,10 +245,11 @@ impl<'a> ImportElisionAnalyzer<'a> {
                 // real code, e.g. function signatures expressed as
                 // tuple types in component decorator metadata.
                 //
-                // Use `as_ts_type()` (the safe `Option`-returning
-                // sibling of `to_ts_type`) for inherited variants, and
-                // unpack the wrapped type for each of the three named
-                // variants explicitly.
+                // `TSTupleElement` adds `TSOptionalType` and `TSRestType` on top of the
+                // inherited `TSType` variants. Use `as_ts_type()` for the common inherited
+                // path and unpack the two named variants explicitly.
+                // `TSNamedTupleMember` is an inherited `TSType` variant and is handled in
+                // the `TSType::TSNamedTupleMember` arm of `collect_computed_keys_from_ts_type`.
                 for element in &tuple_type.element_types {
                     if let Some(ty) = element.as_ts_type() {
                         Self::collect_computed_keys_from_ts_type(ty, result);
@@ -256,27 +257,10 @@ impl<'a> ImportElisionAnalyzer<'a> {
                     }
                     match element {
                         oxc_ast::ast::TSTupleElement::TSOptionalType(opt) => {
-                            Self::collect_computed_keys_from_ts_type(
-                                &opt.type_annotation,
-                                result,
-                            );
+                            Self::collect_computed_keys_from_ts_type(&opt.type_annotation, result);
                         }
                         oxc_ast::ast::TSTupleElement::TSRestType(rest) => {
-                            Self::collect_computed_keys_from_ts_type(
-                                &rest.type_annotation,
-                                result,
-                            );
-                        }
-                        oxc_ast::ast::TSTupleElement::TSNamedTupleMember(named) => {
-                            // `named.element_type` is itself a
-                            // `TSTupleElement`; recurse into its
-                            // inherited TSType (named members
-                            // can't nest per the TS spec, so we
-                            // only need the inherited-variant
-                            // branch here).
-                            if let Some(inner) = named.element_type.as_ts_type() {
-                                Self::collect_computed_keys_from_ts_type(inner, result);
-                            }
+                            Self::collect_computed_keys_from_ts_type(&rest.type_annotation, result);
                         }
                         _ => {}
                     }
@@ -290,10 +274,6 @@ impl<'a> ImportElisionAnalyzer<'a> {
                 }
             }
             TSType::TSNamedTupleMember(named) => {
-                // Named tuple members (`[label: T]`) are inherited TSType variants,
-                // so they reach here via the `as_ts_type()` branch in the TSTupleType
-                // handler. The unreachable match arm added there is a no-op; traversal
-                // must happen here instead.
                 if let Some(inner) = named.element_type.as_ts_type() {
                     Self::collect_computed_keys_from_ts_type(inner, result);
                 }


### PR DESCRIPTION
## Summary

- Fixes a panic in `collect_computed_keys_from_ts_type` when a `TSTupleType` contained `TSOptionalType` (`T?`) or `TSRestType` (`...T[]`) elements — `to_ts_type()` called `unwrap()` on `None` for these variants
- Replaces the panicking `to_ts_type()` call with the safe `as_ts_type()` and adds explicit branches for `TSOptionalType` and `TSRestType`
- Fixes an incomplete handling of `TSNamedTupleMember`: it is an **inherited** `TSType` variant (not a named `TSTupleElement` variant), so it arrives in `collect_computed_keys_from_ts_type` via the `as_ts_type()` path — the match arm added for it in the tuple loop was unreachable; adds a `TSType::TSNamedTupleMember` case to `collect_computed_keys_from_ts_type` so computed property keys inside named tuple member element types are correctly preserved

## Test plan

- [ ] `test_computed_key_in_optional_tuple_element_preserved` — `[myKey]` inside a `T?` element
- [ ] `test_computed_key_in_rest_tuple_element_preserved` — `[myKey]` inside a `...T[]` rest element
- [ ] `test_computed_key_in_named_tuple_member_preserved` — `[myKey]` inside a `label: T` named member
- [ ] `test_tuple_with_mixed_element_kinds_no_panic` — mixed optional/rest/named tuple, confirms no panic
- [ ] All 46 existing `import_elision` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)