### PR TITLE
chore: bump pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "oxlint": "^1.56.0",
     "oxlint-tsgolint": "^0.22.0"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,15 @@ packages:
   - 'napi/angular-compiler/e2e/compare'
   - 'napi/angular-compiler/benchmarks/*'
 
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  core-js: true
+  esbuild: true
+  lmdb: true
+  msgpackr-extract: true
+  protobufjs: true
+
 catalog:
   '@napi-rs/cli': 3.6.2
   '@oxc-node/cli': 0.1.0


### PR DESCRIPTION
Bumps the repo-root `packageManager` pin to `pnpm@11.1.2`.

Only the root `package.json` `packageManager` field is changed.