### PR TITLE
fix(di): resolve `T | null` constructor param types as injection tokens

### DIFF
--- a/crates/oxc_angular_compiler/src/class_metadata/builders.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/builders.rs
@@ -361,7 +361,9 @@ fn build_param_type_expression<'a>(
 /// Used to get the type name for namespace-prefixed references in metadata.
 fn extract_param_type_name<'a>(param: &FormalParameter<'a>) -> Option<Ident<'a>> {
     let type_annotation = param.type_annotation.as_ref()?;
-    match &type_annotation.type_annotation {
+    // Narrow `T | null` unions to `T` so optional-DI patterns expose the type.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
+    match ts_type {
         TSType::TSTypeReference(type_ref) => match &type_ref.type_name {
             TSTypeName::IdentifierReference(id) => Some(id.name.into()),
             TSTypeName::QualifiedName(qualified) => Some(qualified.right.name.into()),
@@ -381,8 +383,11 @@ fn extract_param_type_expression<'a>(
     // Get the type annotation from the formal parameter
     let type_annotation = param.type_annotation.as_ref()?;
 
+    // Narrow `T | null` unions to `T` so optional-DI patterns expose the type.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
+
     // Extract the type name from the annotation
-    match &type_annotation.type_annotation {
+    match ts_type {
         TSType::TSTypeReference(type_ref) => {
             // Handle simple type references like SomeService
             match &type_ref.type_name {

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -1029,7 +1029,8 @@ fn extract_inject_token<'a>(arg: &'a Argument<'a>) -> Option<Ident<'a>> {
 fn extract_param_token<'a>(param: &'a oxc_ast::ast::FormalParameter<'a>) -> Option<Ident<'a>> {
     // Get the type annotation (directly on FormalParameter)
     let type_annotation = param.type_annotation.as_ref()?;
-    let ts_type = &type_annotation.type_annotation;
+    // Narrow `T | null` unions to `T` to match the reference compiler.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
 
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
@@ -2632,6 +2633,136 @@ mod tests {
             let dep = &deps[0];
             assert!(dep.optional, "Should have optional flag");
             assert_eq!(dep.token.as_ref().unwrap().as_str(), "OptionalService");
+        });
+    }
+
+    #[test]
+    fn test_component_optional_with_nullable_type() {
+        // Regression test for issue #285:
+        // `@Optional() svc: MyService | null` is the canonical optional-DI pattern,
+        // but the union with `null` previously caused token extraction to fail and
+        // emit `ɵɵinvalidFactoryDep`, which throws at runtime.
+        //
+        // Angular's reference compiler filters out `null` literal type nodes from
+        // the union; when exactly one type remains it becomes the token.
+        let code = r#"
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                constructor(
+                    @Optional() private svc: MyService | null,
+                ) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.constructor_deps.as_ref().unwrap();
+            assert_eq!(deps.len(), 1);
+            let dep = &deps[0];
+            assert!(dep.optional, "Should have optional flag");
+            assert_eq!(
+                dep.token.as_ref().expect("token should resolve to MyService").as_str(),
+                "MyService",
+                "null should be filtered from the union, leaving MyService as the token",
+            );
+        });
+    }
+
+    #[test]
+    fn test_component_nullable_type_without_decorator() {
+        // Bare `svc: MyService | null` (no `@Optional()`) should also have its
+        // token resolved to `MyService`. Token resolution is independent of
+        // optionality — `@Optional()` only controls the inject flag.
+        let code = r#"
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                constructor(
+                    private svc: MyService | null,
+                ) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.constructor_deps.as_ref().unwrap();
+            assert_eq!(deps.len(), 1);
+            let dep = &deps[0];
+            assert!(!dep.optional, "Should not have optional flag");
+            assert_eq!(
+                dep.token.as_ref().expect("token should resolve to MyService").as_str(),
+                "MyService",
+            );
+        });
+    }
+
+    #[test]
+    fn test_component_nullable_type_null_first() {
+        // `null` can appear in either position of the union — both must be filtered.
+        let code = r#"
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                constructor(
+                    @Optional() private svc: null | MyService,
+                ) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.constructor_deps.as_ref().unwrap();
+            let dep = &deps[0];
+            assert_eq!(dep.token.as_ref().unwrap().as_str(), "MyService");
+        });
+    }
+
+    #[test]
+    fn test_component_parenthesized_nullable_type() {
+        // Parenthesized nullable union: `(MyService | null)`.
+        // oxc preserves `TSParenthesizedType` in the AST, so the resolver must
+        // unwrap it before checking for unions, or the dependency falls through
+        // to `ɵɵinvalidFactoryDep` (issue #285 follow-up).
+        let code = r#"
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                constructor(
+                    @Optional() private svc: (MyService | null),
+                ) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.constructor_deps.as_ref().unwrap();
+            let dep = &deps[0];
+            assert_eq!(
+                dep.token.as_ref().expect("token should resolve to MyService").as_str(),
+                "MyService",
+            );
+        });
+    }
+
+    #[test]
+    fn test_component_paren_around_inner_type_in_union() {
+        // Parens around just the non-null side: `(MyService) | null`.
+        let code = r#"
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                constructor(
+                    @Optional() private svc: (MyService) | null,
+                ) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.constructor_deps.as_ref().unwrap();
+            let dep = &deps[0];
+            assert_eq!(dep.token.as_ref().unwrap().as_str(), "MyService");
         });
     }
 

--- a/crates/oxc_angular_compiler/src/directive/decorator.rs
+++ b/crates/oxc_angular_compiler/src/directive/decorator.rs
@@ -394,7 +394,8 @@ fn extract_param_token<'a>(
 ) -> Option<OutputExpression<'a>> {
     // Get the type annotation (directly on FormalParameter)
     let type_annotation = param.type_annotation.as_ref()?;
-    let ts_type = &type_annotation.type_annotation;
+    // Narrow `T | null` unions to `T` to match the reference compiler.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
 
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
@@ -1533,6 +1534,30 @@ mod tests {
         "#;
         assert_directive_metadata(code, |meta| {
             assert!(meta.uses_inheritance, "Should have inheritance");
+        });
+    }
+
+    #[test]
+    fn test_directive_optional_with_nullable_type() {
+        // Regression test for issue #285:
+        // `@Optional() svc: MyService | null` must resolve the token to `MyService`.
+        let code = r#"
+            @Directive({ selector: '[myDir]' })
+            class MyDirective {
+                constructor(@Optional() private svc: MyService | null) {}
+            }
+        "#;
+        assert_directive_metadata(code, |meta| {
+            let deps = meta.deps.as_ref().expect("Directive should have deps");
+            assert_eq!(deps.len(), 1);
+            let dep = &deps[0];
+            assert!(dep.optional, "Should have optional flag");
+            let token = dep.token.as_ref().expect("token should resolve to MyService");
+            if let crate::output::ast::OutputExpression::ReadVar(var) = token {
+                assert_eq!(var.name.as_str(), "MyService");
+            } else {
+                panic!("expected ReadVar token, got {:?}", token);
+            }
         });
     }
 

--- a/crates/oxc_angular_compiler/src/injectable/decorator.rs
+++ b/crates/oxc_angular_compiler/src/injectable/decorator.rs
@@ -640,7 +640,8 @@ fn extract_param_token<'a>(
 ) -> Option<OutputExpression<'a>> {
     // First try to get the type annotation (directly on FormalParameter, not on pattern)
     let type_annotation = param.type_annotation.as_ref()?;
-    let ts_type = &type_annotation.type_annotation;
+    // Narrow `T | null` unions to `T` to match the reference compiler.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
 
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
@@ -915,6 +916,32 @@ mod tests {
 
         // Third dep: @Inject(DOCUMENT) - token should be DOCUMENT, not Document
         assert!(deps[2].token.is_some(), "Third dep should have token");
+    }
+
+    #[test]
+    fn test_injectable_optional_with_nullable_type() {
+        // Regression test for issue #285:
+        // `@Optional() svc: MyService | null` must resolve the token to `MyService`.
+        let allocator = Allocator::default();
+        let source = r#"
+            @Injectable()
+            class MyService {
+                constructor(@Optional() private svc: OtherService | null) {}
+            }
+        "#;
+
+        let metadata = parse_and_extract(&allocator, source).expect("Should have metadata");
+        let deps = metadata.deps.as_ref().expect("Should have constructor deps");
+        assert_eq!(deps.len(), 1);
+        let dep = &deps[0];
+        assert!(dep.optional, "Should have optional flag");
+        let token = dep.token.as_ref().expect("token should resolve to OtherService");
+        match token {
+            crate::output::ast::OutputExpression::ReadVar(var) => {
+                assert_eq!(var.name.as_str(), "OtherService");
+            }
+            other => panic!("expected ReadVar token, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/oxc_angular_compiler/src/ng_module/decorator.rs
+++ b/crates/oxc_angular_compiler/src/ng_module/decorator.rs
@@ -518,7 +518,8 @@ fn extract_param_token<'a>(
 ) -> Option<OutputExpression<'a>> {
     // First try to get the type annotation (directly on FormalParameter, not on pattern)
     let type_annotation = param.type_annotation.as_ref()?;
-    let ts_type = &type_annotation.type_annotation;
+    // Narrow `T | null` unions to `T` to match the reference compiler.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
 
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
@@ -900,6 +901,31 @@ mod tests {
 
             let dep = &deps[0];
             assert!(dep.token.is_some(), "Token should be extracted from type annotation");
+        });
+    }
+
+    #[test]
+    fn test_ng_module_optional_with_nullable_type() {
+        // Regression test for issue #285:
+        // `@Optional() svc: MyService | null` must resolve the token to `MyService`.
+        let code = r#"
+            @NgModule({})
+            class AppModule {
+                constructor(@Optional() private parent: AppModule | null) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.deps.as_ref().expect("Should have constructor deps");
+            assert_eq!(deps.len(), 1);
+            let dep = &deps[0];
+            assert!(dep.optional);
+            let token = dep.token.as_ref().expect("token should resolve to AppModule");
+            match token {
+                crate::output::ast::OutputExpression::ReadVar(var) => {
+                    assert_eq!(var.name.as_str(), "AppModule");
+                }
+                other => panic!("expected ReadVar token, got {:?}", other),
+            }
         });
     }
 }

--- a/crates/oxc_angular_compiler/src/pipe/decorator.rs
+++ b/crates/oxc_angular_compiler/src/pipe/decorator.rs
@@ -351,7 +351,8 @@ fn extract_param_token<'a>(
 ) -> Option<OutputExpression<'a>> {
     // First try to get the type annotation (directly on FormalParameter, not on pattern)
     let type_annotation = param.type_annotation.as_ref()?;
-    let ts_type = &type_annotation.type_annotation;
+    // Narrow `T | null` unions to `T` to match the reference compiler.
+    let ts_type = crate::util::resolve_di_token_type(&type_annotation.type_annotation)?;
 
     // Handle TSTypeReference: SomeClass, SomeModule, etc.
     if let oxc_ast::ast::TSType::TSTypeReference(type_ref) = ts_type {
@@ -566,6 +567,32 @@ mod tests {
         with_extracted_metadata(code, false, |meta| {
             let meta = meta.expect("Expected metadata");
             assert!(!meta.standalone);
+        });
+    }
+
+    #[test]
+    fn test_pipe_optional_with_nullable_type() {
+        // Regression test for issue #285:
+        // `@Optional() svc: MyService | null` must resolve the token to `MyService`.
+        let code = r#"
+            @Pipe({ name: 'myPipe' })
+            class MyPipe {
+                constructor(@Optional() private svc: MyService | null) {}
+            }
+        "#;
+        assert_metadata(code, |meta| {
+            let deps = meta.deps.as_ref().expect("Should have deps");
+            assert_eq!(deps.len(), 1);
+            let dep = &deps[0];
+            assert!(dep.optional);
+            let token = dep.token.as_ref().expect("token should resolve to MyService");
+            let token: &crate::output::ast::OutputExpression<'_> = token;
+            match token {
+                crate::output::ast::OutputExpression::ReadVar(var) => {
+                    assert_eq!(var.name.as_str(), "MyService");
+                }
+                other => panic!("expected ReadVar token, got {:?}", other),
+            }
         });
     }
 

--- a/crates/oxc_angular_compiler/src/util/mod.rs
+++ b/crates/oxc_angular_compiler/src/util/mod.rs
@@ -3,6 +3,8 @@
 pub mod chars;
 mod deferred_time;
 mod parse_util;
+mod type_extract;
 
 pub use deferred_time::*;
 pub use parse_util::*;
+pub use type_extract::*;

--- a/crates/oxc_angular_compiler/src/util/type_extract.rs
+++ b/crates/oxc_angular_compiler/src/util/type_extract.rs
@@ -1,0 +1,55 @@
+//! Type extraction helpers shared between DI token resolution and class metadata.
+//!
+//! Mirrors Angular's `typeReferenceToExpression` in
+//! `packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts`, which filters
+//! `null` literal type nodes out of a union before resolving the remaining type
+//! as an injection token.
+
+use oxc_ast::ast::TSType;
+
+/// Resolves a TypeScript type annotation to the concrete type usable as a DI
+/// injection token.
+///
+/// When the annotation is a union, `null` keyword variants are filtered out;
+/// if exactly one non-null type remains, that type is returned. Otherwise
+/// (no remaining types, or two or more remaining types) the result is `None`,
+/// matching the reference compiler's "unresolvable token" behavior.
+///
+/// Parenthesized type nodes (`(T)`) are transparently unwrapped before union
+/// handling — oxc preserves them in the AST and the reference compiler treats
+/// them as the inner type for token resolution.
+///
+/// `undefined` is intentionally **not** stripped — this matches Angular's
+/// reference compiler, where `T | undefined` remains ambiguous for token
+/// resolution while `T | null` is the canonical optional-DI pattern.
+///
+/// Non-union, non-parenthesized types are returned as-is.
+pub fn resolve_di_token_type<'a, 'b>(ts_type: &'b TSType<'a>) -> Option<&'b TSType<'a>> {
+    match ts_type {
+        TSType::TSParenthesizedType(paren) => resolve_di_token_type(&paren.type_annotation),
+        TSType::TSUnionType(union) => {
+            let mut non_null = union.types.iter().filter(|t| {
+                // Unwrap parens inside the union so `MyService | (null)` and
+                // `(MyService) | null` both reduce to `MyService`.
+                !matches!(unwrap_parens(t), TSType::TSNullKeyword(_))
+            });
+            let first = non_null.next()?;
+            if non_null.next().is_some() {
+                // More than one non-null type — ambiguous for token resolution.
+                return None;
+            }
+            // Recurse so nested cases like `(MyService | null) | null` collapse.
+            resolve_di_token_type(first)
+        }
+        _ => Some(ts_type),
+    }
+}
+
+/// Strip nested `TSParenthesizedType` wrappers, returning the underlying type.
+fn unwrap_parens<'a, 'b>(ts_type: &'b TSType<'a>) -> &'b TSType<'a> {
+    let mut current = ts_type;
+    while let TSType::TSParenthesizedType(paren) = current {
+        current = &paren.type_annotation;
+    }
+    current
+}


### PR DESCRIPTION
## Summary

- Resolves issue #285. `@Optional() svc: MyService | null` (and the bare `svc: MyService | null` variant) silently emitted `ɵɵinvalidFactoryDep`, which throws at instantiation — the canonical optional-DI pattern was unusable.
- Root cause: five copies of `extract_param_token` (component / directive / injectable / pipe / ng_module) plus two helpers in `class_metadata/builders.rs` only matched bare `TSTypeReference`. Any union annotation fell through to `None`.
- Adds shared helper `util::resolve_di_token_type` that mirrors Angular's `typeReferenceToExpression` in `compiler-cli/src/ngtsc/reflection/src/typescript.ts` — filters `null` keyword variants out of unions and narrows to the sole remaining type, transparently unwrapping `TSParenthesizedType` so `(MyService | null)`, `(MyService) | null`, and `MyService | (null)` all resolve. `undefined` is intentionally preserved to keep `T | undefined` ambiguous, matching the reference.
- Threads the helper through all seven call sites.

## Test plan

- [x] 9 new regression tests across component / directive / injectable / pipe / ng_module — covering `T | null`, `null | T`, parenthesized forms, with and without `@Optional()`.
- [x] `cargo test -p oxc_angular_compiler` — 1044 lib tests pass (+ all integration tests).
- [x] `cargo run -p oxc_angular_conformance` — 1252/1252 conformance cases pass.
- [x] Pre-existing optional-DI tests (`?: T` suffix syntax) still pass; no behavior change for non-union annotations.
- [x] Codex adversarial review caught a follow-up gap (parenthesized types) which is fixed in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DI token resolution across all Angular decorator kinds and class metadata; behavior change is scoped to union/nullable annotations but incorrect narrowing could still mis-emit factory dependencies.
> 
> **Overview**
> Fixes **#285**: constructor params typed as `MyService | null` (with or without `@Optional()`) no longer lose their injection token and emit `ɵɵinvalidFactoryDep` at runtime.
> 
> A shared **`resolve_di_token_type`** helper (aligned with Angular’s reference `typeReferenceToExpression`) strips `null` from unions, unwraps parenthesized types, and leaves `T | undefined` ambiguous. All **`extract_param_token`** paths (component, directive, injectable, pipe, ng_module) and **class metadata** type extraction now use it instead of matching only bare `TSTypeReference`.
> 
> Regression tests cover union order, optional vs non-optional, and parenthesized forms across decorator kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78dd5b7734a1433d750e0299e0b806fbb0d6023c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->