### PR TITLE
fix(decorator): fold `${const}` template literals in metadata fields

### DIFF
--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -6,7 +6,7 @@
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::{
     Argument, ArrayExpressionElement, Class, ClassElement, Decorator, Expression,
-    MethodDefinitionKind, ObjectPropertyKind, PropertyKey, TemplateLiteral,
+    MethodDefinitionKind, ObjectPropertyKind, PropertyKey,
 };
 use oxc_span::Span;
 use oxc_str::Ident;
@@ -91,18 +91,22 @@ pub fn extract_component_metadata<'a>(
 
             match key_name.as_str() {
                 "selector" => {
-                    metadata.selector = extract_string_value(allocator, &prop.value, consts);
+                    metadata.selector =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts);
                 }
                 "template" => {
-                    metadata.template = extract_string_value(allocator, &prop.value, consts);
+                    metadata.template =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts);
                 }
                 "templateUrl" => {
-                    metadata.template_url = extract_string_value(allocator, &prop.value, consts);
+                    metadata.template_url =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts);
                 }
                 "styles" => {
                     if let Some(styles) = extract_string_array(allocator, &prop.value, consts) {
                         metadata.styles = styles;
-                    } else if let Some(style) = extract_string_value(allocator, &prop.value, consts)
+                    } else if let Some(style) =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts)
                     {
                         // Single style string (legacy support)
                         metadata.styles.push(style);
@@ -111,7 +115,9 @@ pub fn extract_component_metadata<'a>(
                 "styleUrls" | "styleUrl" => {
                     if let Some(urls) = extract_string_array(allocator, &prop.value, consts) {
                         metadata.style_urls = urls;
-                    } else if let Some(url) = extract_string_value(allocator, &prop.value, consts) {
+                    } else if let Some(url) =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts)
+                    {
                         metadata.style_urls.push(url);
                     }
                 }
@@ -140,7 +146,9 @@ pub fn extract_component_metadata<'a>(
                 }
                 "exportAs" => {
                     // exportAs can be comma-separated: "foo, bar"
-                    if let Some(export_as) = extract_string_value(allocator, &prop.value, consts) {
+                    if let Some(export_as) =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts)
+                    {
                         for part in export_as.as_str().split(',') {
                             let trimmed = part.trim();
                             if !trimmed.is_empty() {
@@ -360,54 +368,6 @@ fn get_property_key_name<'a>(
     }
 }
 
-/// Extract a string value from an expression.
-///
-/// Resolves same-file `const` identifier references in value position
-/// (`host: { type: FOO }`) and folds `${...}` interpolations inside template
-/// literals (`` template: `<button class="${twBtn}">x</button>` ``) against
-/// the same const map, matching the official Angular compiler's partial
-/// evaluator.
-fn extract_string_value<'a>(
-    allocator: &'a Allocator,
-    expr: &Expression<'a>,
-    consts: &StringConsts<'a>,
-) -> Option<Ident<'a>> {
-    match expr {
-        Expression::StringLiteral(lit) => Some(lit.value.clone().into()),
-        Expression::TemplateLiteral(tpl) => resolve_template_literal(allocator, tpl, consts),
-        Expression::Identifier(id) => consts.get(id.name.as_str()).cloned(),
-        _ => None,
-    }
-}
-
-/// Fold a template literal against the const map.
-///
-/// Empty-interpolation literals (`` `hello` ``) reduce to the cooked quasi.
-/// Otherwise the quasi/expression sequence is interleaved, with each `${...}`
-/// recursively partial-evaluated via `extract_string_value`. If any
-/// interpolation can't fold to a string, the whole literal returns `None` —
-/// matching Angular's all-or-nothing semantics for static metadata.
-fn resolve_template_literal<'a>(
-    allocator: &'a Allocator,
-    tpl: &TemplateLiteral<'a>,
-    consts: &StringConsts<'a>,
-) -> Option<Ident<'a>> {
-    if tpl.expressions.is_empty() {
-        return tpl.quasis.first().and_then(|q| q.value.cooked.clone().map(Into::into));
-    }
-    let mut buf = String::new();
-    // `quasis.len() == expressions.len() + 1`; interleave them.
-    for (i, quasi) in tpl.quasis.iter().enumerate() {
-        let cooked = quasi.value.cooked.as_ref()?;
-        buf.push_str(cooked.as_str());
-        if let Some(expr) = tpl.expressions.get(i) {
-            let resolved = extract_string_value(allocator, expr, consts)?;
-            buf.push_str(resolved.as_str());
-        }
-    }
-    Some(Ident::from(allocator.alloc_str(&buf)))
-}
-
 /// Extract a boolean value from an expression.
 fn extract_boolean_value(expr: &Expression<'_>) -> Option<bool> {
     match expr {
@@ -432,21 +392,12 @@ fn extract_string_array<'a>(
 
     let mut result = Vec::new_in(allocator);
     for element in &arr.elements {
-        match element {
-            ArrayExpressionElement::StringLiteral(lit) => {
-                result.push(lit.value.clone().into());
-            }
-            ArrayExpressionElement::TemplateLiteral(tpl) => {
-                if let Some(value) = resolve_template_literal(allocator, tpl, consts) {
-                    result.push(value);
-                }
-            }
-            ArrayExpressionElement::Identifier(id) => {
-                if let Some(value) = consts.get(id.name.as_str()) {
-                    result.push(value.clone());
-                }
-            }
-            _ => {}
+        // ArrayExpressionElement variants that can hold a value expression all
+        // carry one — funnel them through `as_expression()` and let the shared
+        // resolver decide which shapes fold.
+        let Some(elem_expr) = element.as_expression() else { continue };
+        if let Some(value) = crate::directive::extract_string_value(allocator, elem_expr, consts) {
+            result.push(value);
         }
     }
 
@@ -548,7 +499,8 @@ fn extract_host_metadata<'a>(
             let Some(key_name) = get_property_key_name(&prop.key, consts) else {
                 continue;
             };
-            let Some(value) = extract_string_value(allocator, &prop.value, consts) else {
+            let Some(value) = crate::directive::extract_string_value(allocator, &prop.value, consts)
+            else {
                 continue;
             };
 

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -6,7 +6,7 @@
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::{
     Argument, ArrayExpressionElement, Class, ClassElement, Decorator, Expression,
-    MethodDefinitionKind, ObjectPropertyKind, PropertyKey,
+    MethodDefinitionKind, ObjectPropertyKind, PropertyKey, TemplateLiteral,
 };
 use oxc_span::Span;
 use oxc_str::Ident;
@@ -91,26 +91,27 @@ pub fn extract_component_metadata<'a>(
 
             match key_name.as_str() {
                 "selector" => {
-                    metadata.selector = extract_string_value(&prop.value, consts);
+                    metadata.selector = extract_string_value(allocator, &prop.value, consts);
                 }
                 "template" => {
-                    metadata.template = extract_string_value(&prop.value, consts);
+                    metadata.template = extract_string_value(allocator, &prop.value, consts);
                 }
                 "templateUrl" => {
-                    metadata.template_url = extract_string_value(&prop.value, consts);
+                    metadata.template_url = extract_string_value(allocator, &prop.value, consts);
                 }
                 "styles" => {
-                    if let Some(styles) = extract_string_array(allocator, &prop.value) {
+                    if let Some(styles) = extract_string_array(allocator, &prop.value, consts) {
                         metadata.styles = styles;
-                    } else if let Some(style) = extract_string_value(&prop.value, consts) {
+                    } else if let Some(style) = extract_string_value(allocator, &prop.value, consts)
+                    {
                         // Single style string (legacy support)
                         metadata.styles.push(style);
                     }
                 }
                 "styleUrls" | "styleUrl" => {
-                    if let Some(urls) = extract_string_array(allocator, &prop.value) {
+                    if let Some(urls) = extract_string_array(allocator, &prop.value, consts) {
                         metadata.style_urls = urls;
-                    } else if let Some(url) = extract_string_value(&prop.value, consts) {
+                    } else if let Some(url) = extract_string_value(allocator, &prop.value, consts) {
                         metadata.style_urls.push(url);
                     }
                 }
@@ -139,7 +140,7 @@ pub fn extract_component_metadata<'a>(
                 }
                 "exportAs" => {
                     // exportAs can be comma-separated: "foo, bar"
-                    if let Some(export_as) = extract_string_value(&prop.value, consts) {
+                    if let Some(export_as) = extract_string_value(allocator, &prop.value, consts) {
                         for part in export_as.as_str().split(',') {
                             let trimmed = part.trim();
                             if !trimmed.is_empty() {
@@ -362,20 +363,49 @@ fn get_property_key_name<'a>(
 /// Extract a string value from an expression.
 ///
 /// Resolves same-file `const` identifier references in value position
-/// (`host: { type: FOO }`) so the emitted metadata matches the official
-/// Angular compiler's output.
-fn extract_string_value<'a>(expr: &Expression<'a>, consts: &StringConsts<'a>) -> Option<Ident<'a>> {
+/// (`host: { type: FOO }`) and folds `${...}` interpolations inside template
+/// literals (`` template: `<button class="${twBtn}">x</button>` ``) against
+/// the same const map, matching the official Angular compiler's partial
+/// evaluator.
+fn extract_string_value<'a>(
+    allocator: &'a Allocator,
+    expr: &Expression<'a>,
+    consts: &StringConsts<'a>,
+) -> Option<Ident<'a>> {
     match expr {
         Expression::StringLiteral(lit) => Some(lit.value.clone().into()),
-        Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
-            // Simple template literal with no expressions: `template string`
-            // Use cooked value to properly interpret escape sequences (\n -> newline)
-            // Angular evaluates template literals, so we need cooked, not raw
-            tpl.quasis.first().and_then(|q| q.value.cooked.clone().map(Into::into))
-        }
+        Expression::TemplateLiteral(tpl) => resolve_template_literal(allocator, tpl, consts),
         Expression::Identifier(id) => consts.get(id.name.as_str()).cloned(),
         _ => None,
     }
+}
+
+/// Fold a template literal against the const map.
+///
+/// Empty-interpolation literals (`` `hello` ``) reduce to the cooked quasi.
+/// Otherwise the quasi/expression sequence is interleaved, with each `${...}`
+/// recursively partial-evaluated via `extract_string_value`. If any
+/// interpolation can't fold to a string, the whole literal returns `None` —
+/// matching Angular's all-or-nothing semantics for static metadata.
+fn resolve_template_literal<'a>(
+    allocator: &'a Allocator,
+    tpl: &TemplateLiteral<'a>,
+    consts: &StringConsts<'a>,
+) -> Option<Ident<'a>> {
+    if tpl.expressions.is_empty() {
+        return tpl.quasis.first().and_then(|q| q.value.cooked.clone().map(Into::into));
+    }
+    let mut buf = String::new();
+    // `quasis.len() == expressions.len() + 1`; interleave them.
+    for (i, quasi) in tpl.quasis.iter().enumerate() {
+        let cooked = quasi.value.cooked.as_ref()?;
+        buf.push_str(cooked.as_str());
+        if let Some(expr) = tpl.expressions.get(i) {
+            let resolved = extract_string_value(allocator, expr, consts)?;
+            buf.push_str(resolved.as_str());
+        }
+    }
+    Some(Ident::from(allocator.alloc_str(&buf)))
 }
 
 /// Extract a boolean value from an expression.
@@ -386,9 +416,15 @@ fn extract_boolean_value(expr: &Expression<'_>) -> Option<bool> {
     }
 }
 /// Extract an array of strings from an expression.
+///
+/// `${...}` interpolations inside individual template-literal elements are
+/// folded against `consts` (e.g. `` styles: [`:host { color: ${COLOR}; }`] ``)
+/// to match Angular's partial evaluator. Identifier elements (`[STYLE_CONST]`)
+/// are likewise resolved.
 fn extract_string_array<'a>(
     allocator: &'a Allocator,
     expr: &Expression<'a>,
+    consts: &StringConsts<'a>,
 ) -> Option<Vec<'a, Ident<'a>>> {
     let Expression::ArrayExpression(arr) = expr else {
         return None;
@@ -396,17 +432,21 @@ fn extract_string_array<'a>(
 
     let mut result = Vec::new_in(allocator);
     for element in &arr.elements {
-        if let ArrayExpressionElement::StringLiteral(lit) = element {
-            result.push(lit.value.clone().into());
-        } else if let ArrayExpressionElement::TemplateLiteral(tpl) = element {
-            if tpl.expressions.is_empty() {
-                // Use cooked value to properly interpret escape sequences
-                if let Some(quasi) = tpl.quasis.first() {
-                    if let Some(cooked) = &quasi.value.cooked {
-                        result.push(cooked.clone().into());
-                    }
+        match element {
+            ArrayExpressionElement::StringLiteral(lit) => {
+                result.push(lit.value.clone().into());
+            }
+            ArrayExpressionElement::TemplateLiteral(tpl) => {
+                if let Some(value) = resolve_template_literal(allocator, tpl, consts) {
+                    result.push(value);
                 }
             }
+            ArrayExpressionElement::Identifier(id) => {
+                if let Some(value) = consts.get(id.name.as_str()) {
+                    result.push(value.clone());
+                }
+            }
+            _ => {}
         }
     }
 
@@ -508,7 +548,7 @@ fn extract_host_metadata<'a>(
             let Some(key_name) = get_property_key_name(&prop.key, consts) else {
                 continue;
             };
-            let Some(value) = extract_string_value(&prop.value, consts) else {
+            let Some(value) = extract_string_value(allocator, &prop.value, consts) else {
                 continue;
             };
 
@@ -1168,7 +1208,7 @@ mod tests {
 
         // Build import map from the program body
         let import_map = build_import_map(&allocator, &parser_ret.program.body, None);
-        let consts = crate::directive::collect_string_consts(&parser_ret.program);
+        let consts = crate::directive::collect_string_consts(&allocator, &parser_ret.program);
 
         // Find the first class declaration (handles plain, export default, and export named)
         let mut found_metadata = None;

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -499,7 +499,8 @@ fn extract_host_metadata<'a>(
             let Some(key_name) = get_property_key_name(&prop.key, consts) else {
                 continue;
             };
-            let Some(value) = crate::directive::extract_string_value(allocator, &prop.value, consts)
+            let Some(value) =
+                crate::directive::extract_string_value(allocator, &prop.value, consts)
             else {
                 continue;
             };

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 
 use oxc_allocator::{Allocator, Vec as OxcVec};
 use oxc_ast::ast::{
-    Argument, Declaration, ExportDefaultDeclarationKind, Expression,
-    ImportDeclarationSpecifier, ImportOrExportKind, ObjectPropertyKind, PropertyKey, Statement,
+    Argument, Declaration, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
+    ImportOrExportKind, ObjectPropertyKind, PropertyKey, Statement,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::Parser;
@@ -1195,8 +1195,7 @@ fn build_jit_decorator_text<'a>(
                             {
                                 let import_name =
                                     format!("__NG_CLI_RESOURCE__{}", *resource_counter);
-                                let specifier =
-                                    format!("angular:jit:style:file;{}", url.as_str());
+                                let specifier = format!("angular:jit:style:file;{}", url.as_str());
                                 resource_imports.push((import_name.clone(), specifier));
                                 style_refs.push(import_name);
                                 *resource_counter += 1;

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use oxc_allocator::{Allocator, Vec as OxcVec};
 use oxc_ast::ast::{
-    Argument, ArrayExpressionElement, Declaration, ExportDefaultDeclarationKind, Expression,
+    Argument, Declaration, ExportDefaultDeclarationKind, Expression,
     ImportDeclarationSpecifier, ImportOrExportKind, ObjectPropertyKind, PropertyKey, Statement,
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -1097,12 +1097,18 @@ fn build_ctor_parameters_text(params: &[JitCtorParam]) -> Option<String> {
 /// - `templateUrl: './path'` → `template: __NG_CLI_RESOURCE__N`
 /// - `styleUrl: './path'` → `styles: [__NG_CLI_RESOURCE__N]`
 /// - `styleUrls: ['./a', './b']` → `styles: [__NG_CLI_RESOURCE__N, __NG_CLI_RESOURCE__M]`
-fn build_jit_decorator_text(
+///
+/// `consts` and `allocator` enable folding the same identifier and template-
+/// literal interpolation shapes as the AOT metadata extraction path (e.g.
+/// `` templateUrl: `${DIR}/x.html` `` with a same-file `const DIR = '...'`).
+fn build_jit_decorator_text<'a>(
+    allocator: &'a Allocator,
     source: &str,
-    decorator: &oxc_ast::ast::Decorator<'_>,
+    decorator: &oxc_ast::ast::Decorator<'a>,
     decorator_kind: AngularDecoratorKind,
     resource_counter: &mut u32,
     resource_imports: &mut std::vec::Vec<(String, String)>, // (import_name, specifier)
+    consts: &crate::directive::StringConsts<'a>,
 ) -> String {
     let expr_start = decorator.expression.span().start as usize;
     let expr_end = decorator.expression.span().end as usize;
@@ -1139,10 +1145,14 @@ fn build_jit_decorator_text(
 
             match key_name {
                 Some("templateUrl") => {
-                    // Extract the URL string value
-                    if let Expression::StringLiteral(s) = &prop.value {
+                    // Resolve the URL through the same const/template-literal
+                    // folder used by AOT extraction so JIT and AOT accept the
+                    // same metadata shapes.
+                    if let Some(url) =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts)
+                    {
                         let import_name = format!("__NG_CLI_RESOURCE__{}", *resource_counter);
-                        let specifier = format!("angular:jit:template:file;{}", s.value.as_str());
+                        let specifier = format!("angular:jit:template:file;{}", url.as_str());
                         resource_imports.push((import_name.clone(), specifier));
 
                         // Replace the entire property: `templateUrl: './app.html'` → `template: __NG_CLI_RESOURCE__0`
@@ -1155,9 +1165,11 @@ fn build_jit_decorator_text(
                 }
                 Some("styleUrl") => {
                     // Single style URL
-                    if let Expression::StringLiteral(s) = &prop.value {
+                    if let Some(url) =
+                        crate::directive::extract_string_value(allocator, &prop.value, consts)
+                    {
                         let import_name = format!("__NG_CLI_RESOURCE__{}", *resource_counter);
-                        let specifier = format!("angular:jit:style:file;{}", s.value.as_str());
+                        let specifier = format!("angular:jit:style:file;{}", url.as_str());
                         resource_imports.push((import_name.clone(), specifier));
 
                         let prop_start = prop.span.start as usize - expr_start;
@@ -1168,15 +1180,23 @@ fn build_jit_decorator_text(
                     }
                 }
                 Some("styleUrls") => {
-                    // Array of style URLs
+                    // Array of style URLs — fold each element through the same
+                    // resolver so `${DIR}/a.css`-style entries are accepted.
                     if let Expression::ArrayExpression(arr) = &prop.value {
                         let mut style_refs = std::vec::Vec::new();
                         for elem in &arr.elements {
-                            if let ArrayExpressionElement::StringLiteral(s) = elem {
+                            // ArrayExpressionElement variants that can hold a
+                            // value expression all carry one — funnel them
+                            // through `as_expression()` and let the resolver
+                            // decide which shapes fold.
+                            let Some(elem_expr) = elem.as_expression() else { continue };
+                            if let Some(url) =
+                                crate::directive::extract_string_value(allocator, elem_expr, consts)
+                            {
                                 let import_name =
                                     format!("__NG_CLI_RESOURCE__{}", *resource_counter);
                                 let specifier =
-                                    format!("angular:jit:style:file;{}", s.value.as_str());
+                                    format!("angular:jit:style:file;{}", url.as_str());
                                 resource_imports.push((import_name.clone(), specifier));
                                 style_refs.push(import_name);
                                 *resource_counter += 1;
@@ -1404,6 +1424,11 @@ fn transform_angular_file_jit(
     // are referenced at runtime in ctorParameters. Angular's TS JIT transform
     // patches TypeScript's import elision for the same reason.
 
+    // Collect file-scope string consts so the JIT decorator rewriter can fold
+    // identifier and template-literal references in `templateUrl` / `styleUrl`
+    // / `styleUrls`, matching the AOT metadata extraction path.
+    let string_consts = collect_string_consts(allocator, &parser_ret.program);
+
     // 3. Walk AST to find Angular-decorated classes
     let mut jit_classes: std::vec::Vec<JitClassInfo> = std::vec::Vec::new();
     let mut resource_counter: u32 = 0;
@@ -1448,11 +1473,13 @@ fn transform_angular_file_jit(
             // Check if this is the Angular decorator that needs special text transformation
             if dec.span == angular_decorator.span {
                 let text = build_jit_decorator_text(
+                    allocator,
                     source,
                     dec,
                     decorator_kind,
                     &mut resource_counter,
                     &mut resource_imports,
+                    &string_consts,
                 );
                 all_class_decorator_texts.push(text);
             } else {
@@ -1829,7 +1856,7 @@ pub fn transform_angular_file(
     // Collect file-scope string consts so decorator metadata can resolve identifier
     // references (e.g. `host: { [ATTR_NAME]: '' }`) the same way the official
     // Angular compiler does.
-    let string_consts = collect_string_consts(&parser_ret.program);
+    let string_consts = collect_string_consts(allocator, &parser_ret.program);
 
     #[cfg(feature = "cross_file_elision")]
     let mut import_map =

--- a/crates/oxc_angular_compiler/src/directive/decorator.rs
+++ b/crates/oxc_angular_compiler/src/directive/decorator.rs
@@ -9,7 +9,7 @@ use oxc_allocator::{Allocator, Box, Vec};
 use oxc_ast::ast::{
     Argument, ArrayExpressionElement, BindingPattern, Class, ClassElement, Declaration, Decorator,
     Expression, MethodDefinitionKind, ObjectPropertyKind, Program, PropertyKey, Statement,
-    VariableDeclarationKind,
+    TemplateLiteral, VariableDeclarationKind,
 };
 use oxc_span::Span;
 use oxc_str::Ident;
@@ -126,7 +126,8 @@ pub fn extract_directive_metadata<'a>(
 
                 match key_name.as_str() {
                     "selector" => {
-                        if let Some(selector) = extract_string_value(&prop.value, consts) {
+                        if let Some(selector) = extract_string_value(allocator, &prop.value, consts)
+                        {
                             builder = builder.selector(selector);
                         }
                     }
@@ -136,7 +137,9 @@ pub fn extract_directive_metadata<'a>(
                         }
                     }
                     "exportAs" => {
-                        if let Some(export_as) = extract_string_value(&prop.value, consts) {
+                        if let Some(export_as) =
+                            extract_string_value(allocator, &prop.value, consts)
+                        {
                             // exportAs can be comma-separated: "foo, bar"
                             for part in export_as.as_str().split(',') {
                                 let trimmed = part.trim();
@@ -460,8 +463,18 @@ pub type StringConsts<'a> = HashMap<&'a str, Ident<'a>>;
 ///
 /// Matches both bare `const X = '...'` and `export const X = '...'`. Reassignment
 /// kinds (`let`/`var`) are skipped — only `const` is safe to fold.
-pub fn collect_string_consts<'a>(program: &Program<'a>) -> StringConsts<'a> {
-    let mut map = StringConsts::default();
+///
+/// Resolution is iterative so that chained consts like
+/// `const A = 'a'; const B = `${A}-b`;` fold to their final string values,
+/// matching the official Angular compiler's partial evaluator.
+pub fn collect_string_consts<'a>(
+    allocator: &'a Allocator,
+    program: &Program<'a>,
+) -> StringConsts<'a> {
+    // Collect every top-level `const` binding's name + initializer up front so
+    // we can iterate to a fixed point. Each pending entry is dropped from the
+    // worklist as soon as its initializer folds successfully.
+    let mut pending: std::vec::Vec<(&'a str, &Expression<'a>)> = std::vec::Vec::new();
     for stmt in &program.body {
         let decl = match stmt {
             Statement::VariableDeclaration(d) => d.as_ref(),
@@ -479,9 +492,26 @@ pub fn collect_string_consts<'a>(program: &Program<'a>) -> StringConsts<'a> {
                 continue;
             };
             let Some(init) = &vd.init else { continue };
-            if let Some(value) = literal_string_from_expression(init) {
-                map.insert(id.name.as_str(), value);
+            pending.push((id.name.as_str(), init));
+        }
+    }
+
+    let mut map = StringConsts::default();
+    loop {
+        let before = map.len();
+        pending.retain(|(name, init)| {
+            if map.contains_key(name) {
+                return false;
             }
+            if let Some(value) = extract_string_value(allocator, init, &map) {
+                map.insert(name, value);
+                false
+            } else {
+                true
+            }
+        });
+        if map.len() == before {
+            break;
         }
     }
     map
@@ -497,6 +527,32 @@ fn literal_string_from_expression<'a>(expr: &Expression<'a>) -> Option<Ident<'a>
         }
         _ => None,
     }
+}
+
+/// Fold a template literal whose `${...}` interpolations reference known
+/// string consts. Returns `None` if any interpolation can't be statically
+/// resolved to a string — matching Angular's all-or-nothing partial evaluator
+/// for static metadata fields.
+fn resolve_template_literal<'a>(
+    allocator: &'a Allocator,
+    tpl: &TemplateLiteral<'a>,
+    consts: &StringConsts<'a>,
+) -> Option<Ident<'a>> {
+    if tpl.expressions.is_empty() {
+        return tpl.quasis.first().and_then(|q| q.value.cooked.clone().map(Into::into));
+    }
+    let mut buf = String::new();
+    // A TemplateLiteral has `quasis.len() == expressions.len() + 1`: the
+    // interleaving is quasi[0], expr[0], quasi[1], expr[1], …, quasi[n].
+    for (i, quasi) in tpl.quasis.iter().enumerate() {
+        let cooked = quasi.value.cooked.as_ref()?;
+        buf.push_str(cooked.as_str());
+        if let Some(expr) = tpl.expressions.get(i) {
+            let resolved = extract_string_value(allocator, expr, consts)?;
+            buf.push_str(resolved.as_str());
+        }
+    }
+    Some(Ident::from(allocator.alloc_str(&buf)))
 }
 
 /// Get the name of a property key as a string.
@@ -519,11 +575,17 @@ fn get_property_key_name<'a>(
 /// Extract a string value from an expression.
 ///
 /// Resolves same-file `const` identifier references in value position
-/// (`host: { type: FOO }`) so the emitted metadata matches the official
-/// Angular compiler's output.
-fn extract_string_value<'a>(expr: &Expression<'a>, consts: &StringConsts<'a>) -> Option<Ident<'a>> {
+/// (`host: { type: FOO }`) and folds `${...}` interpolations inside template
+/// literals against the same const map so the emitted metadata matches the
+/// official Angular compiler's partial evaluator.
+pub(crate) fn extract_string_value<'a>(
+    allocator: &'a Allocator,
+    expr: &Expression<'a>,
+    consts: &StringConsts<'a>,
+) -> Option<Ident<'a>> {
     match expr {
         Expression::Identifier(id) => consts.get(id.name.as_str()).cloned(),
+        Expression::TemplateLiteral(tpl) => resolve_template_literal(allocator, tpl, consts),
         _ => literal_string_from_expression(expr),
     }
 }
@@ -555,7 +617,7 @@ fn extract_host_metadata<'a>(
             let Some(key_name) = get_property_key_name(&prop.key, consts) else {
                 continue;
             };
-            let Some(value) = extract_string_value(&prop.value, consts) else {
+            let Some(value) = extract_string_value(allocator, &prop.value, consts) else {
                 continue;
             };
 
@@ -945,7 +1007,7 @@ mod tests {
         let allocator = Allocator::default();
         let source_type = SourceType::tsx();
         let parser_ret = Parser::new(&allocator, code, source_type).parse();
-        let consts = collect_string_consts(&parser_ret.program);
+        let consts = collect_string_consts(&allocator, &parser_ret.program);
 
         let mut found_metadata = None;
         for stmt in &parser_ret.program.body {

--- a/crates/oxc_angular_compiler/src/directive/mod.rs
+++ b/crates/oxc_angular_compiler/src/directive/mod.rs
@@ -24,6 +24,7 @@ pub use compiler::{
     DirectiveCompileResult, compile_directive, compile_directive_from_metadata,
     create_inputs_literal, create_outputs_literal,
 };
+pub(crate) use decorator::extract_string_value;
 pub use decorator::{
     StringConsts, collect_string_consts, extract_directive_metadata, find_directive_decorator_span,
 };

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -9940,3 +9940,347 @@ export class D {}
         result.code
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #286: `${...}` template-literal interpolation in decorator metadata.
+//
+// Angular's partial evaluator constant-folds template literals whose `${...}`
+// expressions reference same-file `const`-bound string values. OXC must match
+// this behavior for `template:`, `selector:`, `styles:`, etc. — otherwise an
+// AOT component silently never matches its tag (or fails to compile at all).
+// ---------------------------------------------------------------------------
+
+/// `template:` may be a template literal interpolating a module-level `const`.
+/// The interpolation must be folded so the component emits a real `ɵcmp` with
+/// the resolved template.
+#[test]
+fn component_template_literal_const_interpolation_in_template() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const twBtn = `px-4 py-2 rounded`;
+
+@Component({
+    selector: 'app-btn',
+    template: `<button class="${twBtn}">x</button>`,
+    standalone: true,
+})
+export class BtnComponent {}
+"#;
+    let result = transform_angular_file(&allocator, "btn.component.ts", source, None, None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    // The component MUST have a real definition emitted.
+    assert!(
+        result.code.contains("ɵɵdefineComponent("),
+        "Expected ɵɵdefineComponent in output (component must be compiled, not skipped).\nCode:\n{}",
+        result.code
+    );
+
+    // The resolved class attribute must reach the output. Angular's template
+    // compiler tokenizes the class string into a `consts: [[1, ...]]` array
+    // (AttributeMarker.Classes == 1), so we check for the tokenized form.
+    let normalized = result.code.replace([' ', '\n', '\t'], "");
+    assert!(
+        normalized.contains(r#"consts:[[1,"px-4","py-2","rounded"]]"#),
+        "Expected resolved class attribute tokens in compiled output.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// `selector:` may be a template literal interpolating a module-level `const`.
+/// The interpolation must be folded so the selector matches its tag at runtime.
+#[test]
+fn component_template_literal_const_interpolation_in_selector() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const PREFIX = 'app';
+
+@Component({
+    selector: `${PREFIX}-btn`,
+    template: '<button>x</button>',
+    standalone: true,
+})
+export class BtnComponent {}
+"#;
+    let result = transform_angular_file(&allocator, "btn.component.ts", source, None, None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let normalized = result.code.replace([' ', '\n', '\t'], "");
+    assert!(
+        normalized.contains(r#"selectors:[["app-btn"]]"#),
+        "Expected selectors:[[\"app-btn\"]] from folded `${{PREFIX}}-btn`.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// `@Directive` selector must also resolve template-literal interpolation.
+#[test]
+fn directive_template_literal_const_interpolation_in_selector() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Directive } from '@angular/core';
+
+const NAME = 'highlight';
+
+@Directive({
+    selector: `[${NAME}]`,
+})
+export class HighlightDirective {}
+"#;
+    let result = transform_angular_file(&allocator, "highlight.directive.ts", source, None, None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let normalized = result.code.replace([' ', '\n', '\t'], "");
+    assert!(
+        normalized.contains(r#"selectors:[[""#) && normalized.contains(r#""highlight""#),
+        "Expected resolved selector containing \"highlight\" attribute in directive definition.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// Multiple `${...}` interpolations in a single template literal must all fold.
+#[test]
+fn component_template_literal_multiple_const_interpolations() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const A = 'hello';
+const B = 'world';
+
+@Component({
+    selector: 'app-multi',
+    template: `<span>${A} ${B}!</span>`,
+    standalone: true,
+})
+export class MultiComponent {}
+"#;
+    let result = transform_angular_file(&allocator, "multi.component.ts", source, None, None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.code.contains("ɵɵdefineComponent("),
+        "Expected ɵɵdefineComponent in output.\nCode:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("hello world!"),
+        "Expected folded text \"hello world!\" in compiled template.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// Chained consts: a const whose initializer interpolates another const must
+/// still resolve when referenced from decorator metadata.
+#[test]
+fn component_chained_const_template_literal_interpolation() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const PREFIX = 'app';
+const TAG = `${PREFIX}-chained`;
+
+@Component({
+    selector: TAG,
+    template: '<span>x</span>',
+    standalone: true,
+})
+export class ChainedComponent {}
+"#;
+    let result = transform_angular_file(&allocator, "chained.component.ts", source, None, None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let normalized = result.code.replace([' ', '\n', '\t'], "");
+    assert!(
+        normalized.contains(r#"selectors:[["app-chained"]]"#),
+        "Expected selectors:[[\"app-chained\"]] from chained const resolution.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// `styles:` array elements may contain `${...}` interpolations referencing
+/// same-file consts; they must fold like `template:` does.
+#[test]
+fn component_styles_template_literal_const_interpolation() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const COLOR = 'red';
+
+@Component({
+    selector: 'app-s',
+    template: '<span>x</span>',
+    styles: [`:host { color: ${COLOR}; }`],
+    standalone: true,
+})
+export class StyledComponent {}
+"#;
+    let result = transform_angular_file(&allocator, "styled.component.ts", source, None, None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.code.contains("color: red"),
+        "Expected folded `color: red` in styles output.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// JIT mode: `templateUrl` may be a template literal interpolating a
+/// module-level `const`. The rewriter must fold and emit the
+/// `angular:jit:template:file;...` import with the resolved path.
+#[test]
+fn jit_template_url_template_literal_const_interpolation() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const DIR = './cmp';
+
+@Component({
+    selector: 'app-root',
+    templateUrl: `${DIR}/x.html`,
+    standalone: true,
+})
+export class AppComponent {}
+"#;
+    let options = ComponentTransformOptions { jit: true, ..Default::default() };
+    let result =
+        transform_angular_file(&allocator, "app.component.ts", source, Some(&options), None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.code.contains("angular:jit:template:file;./cmp/x.html"),
+        "JIT output should import folded template path via angular:jit:template:file.\nCode:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("templateUrl"),
+        "JIT output should replace templateUrl with template.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// JIT mode: `templateUrl` may be a bare identifier referencing a same-file
+/// string `const`. Must also fold.
+#[test]
+fn jit_template_url_const_identifier() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const TPL = './app.html';
+
+@Component({
+    selector: 'app-root',
+    templateUrl: TPL,
+    standalone: true,
+})
+export class AppComponent {}
+"#;
+    let options = ComponentTransformOptions { jit: true, ..Default::default() };
+    let result =
+        transform_angular_file(&allocator, "app.component.ts", source, Some(&options), None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.code.contains("angular:jit:template:file;./app.html"),
+        "JIT output should import resolved template path via angular:jit:template:file.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// JIT mode: `styleUrl` may be a template literal interpolating a `const`.
+#[test]
+fn jit_style_url_template_literal_const_interpolation() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const DIR = './cmp';
+
+@Component({
+    selector: 'app-root',
+    template: '<h1>x</h1>',
+    styleUrl: `${DIR}/x.css`,
+})
+export class AppComponent {}
+"#;
+    let options = ComponentTransformOptions { jit: true, ..Default::default() };
+    let result =
+        transform_angular_file(&allocator, "app.component.ts", source, Some(&options), None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.code.contains("angular:jit:style:file;./cmp/x.css"),
+        "JIT output should import folded style path via angular:jit:style:file.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// JIT mode: `styleUrls:` array elements may be template literals
+/// interpolating a `const`. Each element must fold individually.
+#[test]
+fn jit_style_urls_template_literal_const_interpolation() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+const DIR = './cmp';
+
+@Component({
+    selector: 'app-root',
+    template: '<h1>x</h1>',
+    styleUrls: [`${DIR}/a.css`, './b.css'],
+})
+export class AppComponent {}
+"#;
+    let options = ComponentTransformOptions { jit: true, ..Default::default() };
+    let result =
+        transform_angular_file(&allocator, "app.component.ts", source, Some(&options), None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.code.contains("angular:jit:style:file;./cmp/a.css"),
+        "JIT output should import folded first style path.\nCode:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("angular:jit:style:file;./b.css"),
+        "JIT output should also import the literal second style path.\nCode:\n{}",
+        result.code
+    );
+}
+
+/// An interpolated `${...}` whose identifier is NOT a known const must NOT
+/// crash and must NOT produce a partial/garbage selector — the field is
+/// dropped (same fallback as today for any unresolvable identifier).
+#[test]
+fn component_template_literal_unresolved_identifier_drops_field() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: `${UNRESOLVED}-tag`,
+    template: '<span>x</span>',
+    standalone: true,
+})
+export class UnresolvedComponent {}
+"#;
+    let result = transform_angular_file(&allocator, "u.component.ts", source, None, None);
+    // Must not crash.
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    // Must not emit a selector containing an unresolved literal.
+    assert!(
+        !result.code.contains("${UNRESOLVED}-tag"),
+        "Unresolved interpolation must not leak verbatim into selectors.\nCode:\n{}",
+        result.code
+    );
+}

--- a/napi/angular-compiler/src/lib.rs
+++ b/napi/angular-compiler/src/lib.rs
@@ -749,7 +749,7 @@ pub fn extract_component_urls_sync(source: String, filename: String) -> Componen
 
     // Build import map for component metadata extraction
     let import_map = build_import_map(&allocator, &program.body, None);
-    let string_consts = collect_string_consts(program);
+    let string_consts = collect_string_consts(&allocator, program);
 
     let mut template_urls = Vec::new();
     let mut style_urls = Vec::new();
@@ -1515,7 +1515,7 @@ pub fn extract_component_metadata_sync(
 
     // Build import map for component metadata extraction
     let import_map = build_import_map(&allocator, &program.body, None);
-    let string_consts = collect_string_consts(program);
+    let string_consts = collect_string_consts(&allocator, program);
 
     let mut results = Vec::new();
     let emitter = JsEmitter::new();


### PR DESCRIPTION
## Summary

- Resolves [#286](https://github.com/voidzero-dev/oxc-angular-compiler/issues/286): `template:` / `selector:` with `${const}` template-literal interpolation were silently dropped (AOT skipped the component, no `ɵcmp`; or emitted `selectors:[["ng-component"]]`).
- `extract_string_value` in `component/decorator.rs` and `directive/decorator.rs` now recursively folds `${...}` expressions through the existing `StringConsts` map; nested/chained consts resolve via an iterative fixed-point in `collect_string_consts`.
- JIT mode's `build_jit_decorator_text` shares the same resolver, so `templateUrl` / `styleUrl` / `styleUrls` accept the same identifier and template-literal shapes as AOT (closes the AOT/JIT asymmetry surfaced by `/codex:adversarial-review`).

## Root cause

`extract_string_value` rejected any `TemplateLiteral` with non-empty `expressions`, so `` template: `<button class="${twBtn}">x</button>` `` returned `None` and the whole `@Component` decorator was treated as un-extractable. `StringConsts` from #271 was only consulted for bare identifier references.

## Changes

- `crates/oxc_angular_compiler/src/directive/decorator.rs`: add `resolve_template_literal` (interleaves quasis with partial-evaluated `${...}` expressions); thread `&'a Allocator` through `extract_string_value`; iterative fixed-point in `collect_string_consts` for chained consts; export `extract_string_value` as `pub(crate)`.
- `crates/oxc_angular_compiler/src/component/decorator.rs`: mirror `resolve_template_literal`; thread allocator through `extract_string_value` and `extract_string_array` (which also accepts `[CONST_STR]` and `` [`${CONST}`] `` array elements).
- `crates/oxc_angular_compiler/src/component/transform.rs`: collect `string_consts` in the JIT path and feed `build_jit_decorator_text`, which now resolves URL values through the shared `extract_string_value` so `` templateUrl: `${DIR}/x.html` `` and `templateUrl: PATH_CONST` fold in JIT too.
- `crates/oxc_angular_compiler/src/directive/mod.rs`: `pub(crate) use decorator::extract_string_value`.
- `napi/angular-compiler/src/lib.rs`: pass allocator to `collect_string_consts` in `extract_component_urls_sync` and `extract_metadata_sync`.

## Test plan

- [x] `cargo test -p oxc_angular_compiler` — 2454 passed, 0 failed, 1 ignored (pre-existing).
- [x] 11 new integration tests in `tests/integration_test.rs` covering AOT `template:`/`selector:` interpolation in `@Component` and `@Directive`, multiple interpolations, chained consts (`const TAG = \`${PREFIX}-x\``), `styles:` array elements, graceful fallback on unresolved identifiers, plus JIT `templateUrl` / `styleUrl` / `styleUrls` for both template-literal and identifier shapes.
- [x] `cargo build --all-targets` — clean (only pre-existing missing-docs warnings).
- [x] Reviewed via `/codex:adversarial-review` — initial pass flagged the JIT gap, which this PR also closes; re-verified with the full extended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core decorator metadata extraction and JIT decorator rewriting; incorrect folding could change selectors, templates, or resource paths, though behavior is constrained to statically resolvable same-file consts with tests covering main shapes.
> 
> **Overview**
> Fixes **#286**: decorator metadata that used `` `${const}` `` template literals (or const identifiers) in fields like `template`, `selector`, and `styles` were treated as unextractable, so AOT could skip `ɵɵdefineComponent` or emit wrong selectors.
> 
> **Shared partial evaluation** in `directive/decorator.rs`: `extract_string_value` now folds template literals via `resolve_template_literal`, and `collect_string_consts` takes an allocator and resolves chained top-level `const` values in a fixed-point loop. Component and directive metadata parsing route string fields and `styles` / `styleUrls` array elements through this helper instead of local duplicate logic.
> 
> **JIT parity**: `build_jit_decorator_text` collects `string_consts` and resolves `templateUrl`, `styleUrl`, and `styleUrls` the same way, so `angular:jit:*:file;` imports get folded paths. NAPI call sites pass the allocator into `collect_string_consts`.
> 
> Eleven integration tests cover AOT/JIT folding, chained consts, and graceful drop when interpolations cannot be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3bb67053257e21d5a5658908e6c61b8beb6e3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->