### PR TITLE
fix(di): emit ɵɵinvalidFactory for type-only constructor parameter imports

### DIFF
--- a/crates/oxc_angular_compiler/src/class_metadata/builders.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/builders.rs
@@ -762,6 +762,13 @@ fn build_param_type_expression<'a>(
     // Use namespace prefix when the type annotation matches the dep token name
     // and the dep has a source module (imported type).
     if let Some(dep) = dep {
+        // Type-only imports cannot be referenced at runtime — emit `undefined`
+        // in the metadata, matching the behaviour Angular's `typeToValue()`
+        // uses for `ValueUnavailableKind.TYPE_ONLY_IMPORT`. See issue #288.
+        if dep.type_only_invalid {
+            return None;
+        }
+
         if let Some(ref source_module) = dep.token_source_module {
             if let Some(ref token) = dep.token {
                 let type_matches_token =

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -964,16 +964,26 @@ fn extract_param_dependency<'a>(
     // Build the dependency metadata
     let mut dep = match &token {
         Some(token_name) => {
-            let mut d = R3DependencyMetadata::new(token_name.clone());
             // Look up the token in the import map to find its source module and import type
             if let Some(import_info) = import_map.get(token_name) {
-                d.token_source_module = Some(import_info.source_module.clone());
-                // Always use namespace imports for DI tokens (has_named_import = false).
-                // Import elision removes @Inject(TOKEN) argument imports since they're
-                // only used in decorator positions that get compiled away.
-                // Using bare TOKEN would fail at runtime because the import is gone.
+                if import_info.is_type_only {
+                    // Type-only imports (`import type { X }` / `import { type X }`)
+                    // are erased at runtime and cannot be used as DI tokens. The whole
+                    // factory must collapse to `ɵɵinvalidFactory()` — matching Angular's
+                    // `ValueUnavailableKind.TYPE_ONLY_IMPORT`. See issue #288.
+                    R3DependencyMetadata::type_only_invalid()
+                } else {
+                    let mut d = R3DependencyMetadata::new(token_name.clone());
+                    d.token_source_module = Some(import_info.source_module.clone());
+                    // Always use namespace imports for DI tokens (has_named_import = false).
+                    // Import elision removes @Inject(TOKEN) argument imports since they're
+                    // only used in decorator positions that get compiled away.
+                    // Using bare TOKEN would fail at runtime because the import is gone.
+                    d
+                }
+            } else {
+                R3DependencyMetadata::new(token_name.clone())
             }
-            d
         }
         None => R3DependencyMetadata::invalid(),
     };

--- a/crates/oxc_angular_compiler/src/component/definition.rs
+++ b/crates/oxc_angular_compiler/src/component/definition.rs
@@ -27,6 +27,7 @@ use super::transform::TransformOptions;
 use crate::directive::{
     create_host_directive_mappings_array, create_inputs_literal, create_outputs_literal,
 };
+use crate::factory::create_invalid_factory_call;
 use crate::output::ast::{
     FnParam, FunctionExpr, InstantiateExpr, InvokeFunctionExpr, LiteralArrayExpr, LiteralExpr,
     LiteralMapEntry, LiteralMapExpr, LiteralValue, OutputExpression, OutputStatement, ReadPropExpr,
@@ -35,39 +36,6 @@ use crate::output::ast::{
 use crate::pipeline::compilation::{ComponentCompilationJob, ConstValue};
 use crate::pipeline::emit::HostBindingCompilationResult;
 use crate::pipeline::selector::{parse_selector_to_r3_selector, r3_selector_to_output_expr};
-
-/// Create an `i0.ɵɵinvalidFactory()` call expression.
-///
-/// Used when constructor dependencies cannot be resolved at runtime (e.g.,
-/// a type-only import was used as a DI token).
-fn create_invalid_factory_call(allocator: &Allocator) -> OutputExpression<'_> {
-    let fn_expr = OutputExpression::ReadProp(Box::new_in(
-        ReadPropExpr {
-            receiver: Box::new_in(
-                OutputExpression::ReadVar(Box::new_in(
-                    ReadVarExpr { name: Ident::from("i0"), source_span: None },
-                    allocator,
-                )),
-                allocator,
-            ),
-            name: Ident::from(Identifiers::INVALID_FACTORY),
-            optional: false,
-            source_span: None,
-        },
-        allocator,
-    ));
-
-    OutputExpression::InvokeFunction(Box::new_in(
-        InvokeFunctionExpr {
-            fn_expr: Box::new_in(fn_expr, allocator),
-            args: OxcVec::new_in(allocator),
-            pure: false,
-            optional: false,
-            source_span: None,
-        },
-        allocator,
-    ))
-}
 
 /// Result of generating component definitions.
 pub struct ComponentDefinitions<'a> {

--- a/crates/oxc_angular_compiler/src/component/definition.rs
+++ b/crates/oxc_angular_compiler/src/component/definition.rs
@@ -36,6 +36,39 @@ use crate::pipeline::compilation::{ComponentCompilationJob, ConstValue};
 use crate::pipeline::emit::HostBindingCompilationResult;
 use crate::pipeline::selector::{parse_selector_to_r3_selector, r3_selector_to_output_expr};
 
+/// Create an `i0.ɵɵinvalidFactory()` call expression.
+///
+/// Used when constructor dependencies cannot be resolved at runtime (e.g.,
+/// a type-only import was used as a DI token).
+fn create_invalid_factory_call(allocator: &Allocator) -> OutputExpression<'_> {
+    let fn_expr = OutputExpression::ReadProp(Box::new_in(
+        ReadPropExpr {
+            receiver: Box::new_in(
+                OutputExpression::ReadVar(Box::new_in(
+                    ReadVarExpr { name: Ident::from("i0"), source_span: None },
+                    allocator,
+                )),
+                allocator,
+            ),
+            name: Ident::from(Identifiers::INVALID_FACTORY),
+            optional: false,
+            source_span: None,
+        },
+        allocator,
+    ));
+
+    OutputExpression::InvokeFunction(Box::new_in(
+        InvokeFunctionExpr {
+            fn_expr: Box::new_in(fn_expr, allocator),
+            args: OxcVec::new_in(allocator),
+            pure: false,
+            optional: false,
+            source_span: None,
+        },
+        allocator,
+    ))
+}
+
 /// Result of generating component definitions.
 pub struct ComponentDefinitions<'a> {
     /// The ɵcmp definition (component metadata for Angular runtime).
@@ -627,6 +660,25 @@ fn generate_constructor_factory<'a>(
         },
         allocator,
     ));
+
+    // If any constructor parameter resolved to a type-only import, the whole
+    // factory cannot be formed at runtime. Emit `i0.ɵɵinvalidFactory()` instead
+    // of a `new ClassCtor(...)` expression — matching Angular's
+    // `ValueUnavailableKind.TYPE_ONLY_IMPORT` behaviour. See issue #288.
+    if deps.iter().any(|d| d.type_only_invalid) {
+        statements.push(OutputStatement::Expression(Box::new_in(
+            crate::output::ast::ExpressionStatement {
+                expr: create_invalid_factory_call(allocator),
+                source_span: None,
+            },
+            allocator,
+        )));
+
+        return OutputExpression::Function(Box::new_in(
+            FunctionExpr { name: Some(fn_name), params, statements, source_span: None },
+            allocator,
+        ));
+    }
 
     // Compile constructor dependencies if any
     // Uses FactoryTarget::Component for components

--- a/crates/oxc_angular_compiler/src/component/dependency.rs
+++ b/crates/oxc_angular_compiler/src/component/dependency.rs
@@ -60,6 +60,15 @@ pub struct R3DependencyMetadata<'a> {
 
     /// Whether `@SkipSelf()` decorator is present.
     pub skip_self: bool,
+
+    /// Whether this dependency's token came from a type-only import
+    /// (`import type { X }` or `import { type X }`).
+    ///
+    /// Such imports are erased at runtime, so the token cannot be resolved to a
+    /// value. When this flag is set on any constructor dependency, the factory
+    /// as a whole becomes `ɵɵinvalidFactory()` — matching Angular's
+    /// `ValueUnavailableKind.TYPE_ONLY_IMPORT` behaviour. See issue #288.
+    pub type_only_invalid: bool,
 }
 
 impl<'a> R3DependencyMetadata<'a> {
@@ -74,6 +83,7 @@ impl<'a> R3DependencyMetadata<'a> {
             optional: false,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
         }
     }
 
@@ -88,6 +98,25 @@ impl<'a> R3DependencyMetadata<'a> {
             optional: false,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
+        }
+    }
+
+    /// Create an invalid dependency caused by a type-only import.
+    ///
+    /// Used when a constructor parameter's type annotation resolves to a
+    /// type-only import. The whole factory must become `ɵɵinvalidFactory()`.
+    pub fn type_only_invalid() -> Self {
+        Self {
+            token: None,
+            token_source_module: None,
+            has_named_import: false,
+            attribute_name: None,
+            host: false,
+            optional: false,
+            self_: false,
+            skip_self: false,
+            type_only_invalid: true,
         }
     }
 
@@ -126,6 +155,7 @@ impl<'a> R3DependencyMetadata<'a> {
             optional: false,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
         }
     }
 

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -573,6 +573,16 @@ fn resolve_factory_dep_namespaces<'a>(
         let name = &var.name;
         // Look up this identifier in the import map
         let Some(import_info) = import_map.get(name) else { continue };
+        if import_info.is_type_only {
+            // Type-only imports (`import type { X }` / `import { type X }`) are erased
+            // at runtime, so they cannot be used as DI tokens. Flag the dep so the
+            // factory collapses to `ɵɵinvalidFactory()` and avoid registering a
+            // namespace that would otherwise add a runtime import for the module.
+            // See issue #288.
+            dep.token = None;
+            dep.type_only_invalid = true;
+            continue;
+        }
         // Replace with namespace-prefixed reference: i1.Store instead of Store
         let namespace = namespace_registry.get_or_assign(&import_info.source_module);
         dep.token = Some(OutputExpression::ReadProp(oxc_allocator::Box::new_in(

--- a/crates/oxc_angular_compiler/src/directive/decorator.rs
+++ b/crates/oxc_angular_compiler/src/directive/decorator.rs
@@ -364,10 +364,19 @@ fn extract_param_dependency<'a>(
             optional,
             self_,
             skip_self,
+            type_only_invalid: false,
         };
     }
 
-    R3DependencyMetadata { token, attribute_name_type: None, host, optional, self_, skip_self }
+    R3DependencyMetadata {
+        token,
+        attribute_name_type: None,
+        host,
+        optional,
+        self_,
+        skip_self,
+        type_only_invalid: false,
+    }
 }
 
 /// Get the name of a decorator from its expression.

--- a/crates/oxc_angular_compiler/src/directive/definition.rs
+++ b/crates/oxc_angular_compiler/src/directive/definition.rs
@@ -155,6 +155,7 @@ fn generate_fac_definition<'a>(
                     optional: dep.optional,
                     self_: dep.self_,
                     skip_self: dep.skip_self,
+                    type_only_invalid: dep.type_only_invalid,
                 });
             }
             R3FactoryDeps::Valid(factory_deps)

--- a/crates/oxc_angular_compiler/src/factory/compiler.rs
+++ b/crates/oxc_angular_compiler/src/factory/compiler.rs
@@ -699,8 +699,8 @@ fn create_import_call<'a>(
     ))
 }
 
-/// Creates i0.ɵɵinvalidFactory() call.
-fn create_invalid_factory_call<'a>(allocator: &'a Allocator) -> OutputExpression<'a> {
+/// Creates `i0.ɵɵinvalidFactory()` call.
+pub fn create_invalid_factory_call<'a>(allocator: &'a Allocator) -> OutputExpression<'a> {
     create_import_call(allocator, Identifiers::INVALID_FACTORY, Vec::new_in(allocator))
 }
 

--- a/crates/oxc_angular_compiler/src/factory/compiler.rs
+++ b/crates/oxc_angular_compiler/src/factory/compiler.rs
@@ -140,6 +140,11 @@ pub fn compile_factory_function<'a>(
     // Build the constructor expression based on deps
     // See: r3_factory.ts:119-129
     let ctor_expr: Option<OutputExpression<'a>> = match &base.deps {
+        R3FactoryDeps::Valid(deps) if deps.iter().any(|d| d.type_only_invalid) => {
+            // A constructor parameter resolves to a type-only import; the factory
+            // as a whole cannot be formed. Force `ɵɵinvalidFactory()`. See #288.
+            None
+        }
         R3FactoryDeps::Valid(deps) => {
             // new (type)(ɵɵinject(Dep1), ɵɵinject(Dep2), ...)
             let inject_args = inject_dependencies(allocator, deps.as_slice(), base.target);

--- a/crates/oxc_angular_compiler/src/factory/metadata.rs
+++ b/crates/oxc_angular_compiler/src/factory/metadata.rs
@@ -55,6 +55,14 @@ pub struct R3DependencyMetadata<'a> {
 
     /// Whether the dependency has an @SkipSelf qualifier.
     pub skip_self: bool,
+
+    /// Whether this dependency's token came from a type-only import.
+    ///
+    /// Type-only imports (`import type { X }` or `import { type X }`) are erased
+    /// at runtime; if any constructor dependency has this flag set, the factory
+    /// as a whole must become `ɵɵinvalidFactory()` — matching Angular's
+    /// `ValueUnavailableKind.TYPE_ONLY_IMPORT`. See issue #288.
+    pub type_only_invalid: bool,
 }
 
 impl<'a> R3DependencyMetadata<'a> {
@@ -67,6 +75,7 @@ impl<'a> R3DependencyMetadata<'a> {
             optional: false,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
         }
     }
 
@@ -79,6 +88,7 @@ impl<'a> R3DependencyMetadata<'a> {
             optional: true,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
         }
     }
 }

--- a/crates/oxc_angular_compiler/src/factory/mod.rs
+++ b/crates/oxc_angular_compiler/src/factory/mod.rs
@@ -8,7 +8,9 @@
 mod compiler;
 mod metadata;
 
-pub use compiler::{FactoryCompileResult, InjectFlags, compile_factory_function};
+pub use compiler::{
+    FactoryCompileResult, InjectFlags, compile_factory_function, create_invalid_factory_call,
+};
 pub use metadata::{
     FactoryTarget, R3ConstructorFactoryMetadata, R3DelegatedFnOrClassMetadata,
     R3DependencyMetadata, R3ExpressionFactoryMetadata, R3FactoryDelegateType, R3FactoryDeps,

--- a/crates/oxc_angular_compiler/src/injectable/compiler.rs
+++ b/crates/oxc_angular_compiler/src/injectable/compiler.rs
@@ -188,6 +188,7 @@ fn clone_deps_vec<'a>(
             optional: dep.optional,
             self_: dep.self_,
             skip_self: dep.skip_self,
+            type_only_invalid: dep.type_only_invalid,
         });
     }
     result
@@ -664,6 +665,7 @@ mod tests {
             optional: false,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
         });
 
         let metadata = R3InjectableMetadataBuilder::new()
@@ -721,6 +723,7 @@ mod tests {
             optional: false,
             self_: false,
             skip_self: false,
+            type_only_invalid: false,
         });
 
         let metadata = R3InjectableMetadataBuilder::new()

--- a/crates/oxc_angular_compiler/src/injectable/decorator.rs
+++ b/crates/oxc_angular_compiler/src/injectable/decorator.rs
@@ -181,6 +181,7 @@ fn clone_r3_deps<'a>(
             optional: dep.optional,
             self_: dep.self_,
             skip_self: dep.skip_self,
+            type_only_invalid: dep.type_only_invalid,
         });
     }
     result
@@ -199,6 +200,7 @@ fn convert_deps_to_r3<'a>(
             optional: dep.optional,
             self_: dep.self_,
             skip_self: dep.skip_self,
+            type_only_invalid: false,
         });
     }
     result
@@ -617,10 +619,19 @@ fn extract_param_dependency<'a>(
             optional,
             self_,
             skip_self,
+            type_only_invalid: false,
         };
     }
 
-    R3DependencyMetadata { token, attribute_name_type: None, host, optional, self_, skip_self }
+    R3DependencyMetadata {
+        token,
+        attribute_name_type: None,
+        host,
+        optional,
+        self_,
+        skip_self,
+        type_only_invalid: false,
+    }
 }
 
 /// Get the name of a decorator from its expression.

--- a/crates/oxc_angular_compiler/src/injectable/definition.rs
+++ b/crates/oxc_angular_compiler/src/injectable/definition.rs
@@ -154,6 +154,7 @@ fn generate_fac_definition<'a>(
                     optional: dep.optional,
                     self_: dep.self_,
                     skip_self: dep.skip_self,
+                    type_only_invalid: dep.type_only_invalid,
                 });
             }
             R3FactoryDeps::Valid(factory_deps)

--- a/crates/oxc_angular_compiler/src/ng_module/decorator.rs
+++ b/crates/oxc_angular_compiler/src/ng_module/decorator.rs
@@ -490,10 +490,19 @@ fn extract_param_dependency<'a>(
             optional,
             self_,
             skip_self,
+            type_only_invalid: false,
         };
     }
 
-    R3DependencyMetadata { token, attribute_name_type: None, host, optional, self_, skip_self }
+    R3DependencyMetadata {
+        token,
+        attribute_name_type: None,
+        host,
+        optional,
+        self_,
+        skip_self,
+        type_only_invalid: false,
+    }
 }
 
 /// Get the name of a decorator from its expression.

--- a/crates/oxc_angular_compiler/src/ng_module/definition.rs
+++ b/crates/oxc_angular_compiler/src/ng_module/definition.rs
@@ -237,6 +237,7 @@ fn generate_ng_module_fac<'a>(
                     optional: dep.optional,
                     self_: dep.self_,
                     skip_self: dep.skip_self,
+                    type_only_invalid: dep.type_only_invalid,
                 });
             }
             R3FactoryDeps::Valid(factory_deps)

--- a/crates/oxc_angular_compiler/src/pipe/decorator.rs
+++ b/crates/oxc_angular_compiler/src/pipe/decorator.rs
@@ -323,10 +323,19 @@ fn extract_param_dependency<'a>(
             optional,
             self_,
             skip_self,
+            type_only_invalid: false,
         };
     }
 
-    R3DependencyMetadata { token, attribute_name_type: None, host, optional, self_, skip_self }
+    R3DependencyMetadata {
+        token,
+        attribute_name_type: None,
+        host,
+        optional,
+        self_,
+        skip_self,
+        type_only_invalid: false,
+    }
 }
 
 /// Get the name of a decorator from its expression.

--- a/crates/oxc_angular_compiler/src/pipe/definition.rs
+++ b/crates/oxc_angular_compiler/src/pipe/definition.rs
@@ -182,6 +182,7 @@ fn generate_pipe_fac<'a>(
                     optional: dep.optional,
                     self_: dep.self_,
                     skip_self: dep.skip_self,
+                    type_only_invalid: dep.type_only_invalid,
                 });
             }
             R3FactoryDeps::Valid(factory_deps)

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -12623,3 +12623,188 @@ const TOKEN = 'tok';
         result.code
     );
 }
+
+// =============================================================================
+// Regression tests for issue #288 — type-only constructor parameters
+// =============================================================================
+//
+// When a constructor parameter's type annotation comes from a type-only import
+// (`import type { X }` or `import { type X }`), TypeScript erases the import at
+// runtime. The Angular reference compiler responds with `ɵɵinvalidFactory()`
+// (`ValueUnavailableKind.TYPE_ONLY_IMPORT`) instead of an `ɵɵdirectiveInject(X)`
+// call that would crash with `token must be defined`.
+
+/// Issue #288: `import type { MyService }` constructor params must not emit a
+/// runtime DI token.
+///
+/// A type-only import is erased at runtime, so neither a namespace import for
+/// the module nor a `directiveInject(i1.MyService)` call may be generated. The
+/// factory body must instead be `ɵɵinvalidFactory()`.
+#[test]
+fn test_component_type_only_import_emits_invalid_factory() {
+    let allocator = Allocator::default();
+
+    let source = r"
+import { Component } from '@angular/core';
+import type { MyService } from './my-service';
+
+@Component({
+    selector: 'x',
+    template: '',
+    standalone: true,
+})
+export class X {
+    constructor(private svc: MyService) {}
+}
+";
+
+    let result = transform_angular_file(&allocator, "x.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    assert!(
+        !code.lines().any(|l| l.trim_start().starts_with("import * as ")
+            && (l.contains("'./my-service'") || l.contains("\"./my-service\""))),
+        "type-only import './my-service' must not be promoted to a runtime namespace import.\nOutput:\n{code}"
+    );
+
+    assert!(
+        !code.contains("i1.MyService"),
+        "Must not emit namespace-prefixed `i1.MyService` for a type-only import.\nOutput:\n{code}"
+    );
+    assert!(
+        !code.contains("directiveInject(MyService)"),
+        "Must not emit a bare `directiveInject(MyService)` for a type-only import.\nOutput:\n{code}"
+    );
+
+    let factory_section =
+        code.split("ɵfac").nth(1).expect("Should have a factory definition (ɵfac)");
+    assert!(
+        factory_section.contains("ɵɵinvalidFactory()"),
+        "Type-only DI param must produce `ɵɵinvalidFactory()`. Factory:\n{factory_section}"
+    );
+}
+
+/// Issue #288: `import { type MyService }` (inline type specifier) must behave
+/// the same as a declaration-level `import type`.
+#[test]
+fn test_component_inline_type_specifier_emits_invalid_factory() {
+    let allocator = Allocator::default();
+
+    let source = r"
+import { Component } from '@angular/core';
+import { type MyService } from './my-service';
+
+@Component({
+    selector: 'x',
+    template: '',
+    standalone: true,
+})
+export class X {
+    constructor(private svc: MyService) {}
+}
+";
+
+    let result = transform_angular_file(&allocator, "x.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    assert!(
+        !code.contains("from './my-service'") && !code.contains("from \"./my-service\""),
+        "inline `type` specifier must not promote './my-service' to a runtime import.\nOutput:\n{code}"
+    );
+    assert!(
+        !code.contains("i1.MyService"),
+        "Must not emit namespace-prefixed `i1.MyService` for a type-only specifier.\nOutput:\n{code}"
+    );
+
+    let factory_section =
+        code.split("ɵfac").nth(1).expect("Should have a factory definition (ɵfac)");
+    assert!(
+        factory_section.contains("ɵɵinvalidFactory()"),
+        "Inline `type` specifier DI param must produce `ɵɵinvalidFactory()`. Factory:\n{factory_section}"
+    );
+}
+
+/// Issue #288: directives with type-only DI tokens must also emit
+/// `ɵɵinvalidFactory()` instead of a runtime namespace reference.
+#[test]
+fn test_directive_type_only_import_emits_invalid_factory() {
+    let allocator = Allocator::default();
+
+    let source = r"
+import { Directive } from '@angular/core';
+import type { MyService } from './my-service';
+
+@Directive({
+    selector: '[appX]',
+    standalone: true,
+})
+export class XDirective {
+    constructor(private svc: MyService) {}
+}
+";
+
+    let result = transform_angular_file(&allocator, "x.directive.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    assert!(
+        !code.lines().any(|l| l.trim_start().starts_with("import * as ")
+            && (l.contains("'./my-service'") || l.contains("\"./my-service\""))),
+        "type-only import './my-service' must not be promoted to a runtime namespace import.\nOutput:\n{code}"
+    );
+    assert!(
+        !code.contains("i1.MyService"),
+        "Must not emit namespace-prefixed `i1.MyService` for a type-only directive param.\nOutput:\n{code}"
+    );
+
+    let factory_section =
+        code.split("ɵfac").nth(1).expect("Should have a factory definition (ɵfac)");
+    assert!(
+        factory_section.contains("ɵɵinvalidFactory()"),
+        "Directive type-only DI param must produce `ɵɵinvalidFactory()`. Factory:\n{factory_section}"
+    );
+}
+
+/// Issue #288: injectables (`@Injectable`) with type-only DI tokens must also
+/// emit `ɵɵinvalidFactory()`.
+#[test]
+fn test_injectable_type_only_import_emits_invalid_factory() {
+    let allocator = Allocator::default();
+
+    let source = r"
+import { Injectable } from '@angular/core';
+import type { MyDep } from './my-dep';
+
+@Injectable({ providedIn: 'root' })
+export class MyService {
+    constructor(private dep: MyDep) {}
+}
+";
+
+    let result = transform_angular_file(&allocator, "my-service.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    assert!(
+        !code.lines().any(|l| l.trim_start().starts_with("import * as ")
+            && (l.contains("'./my-dep'") || l.contains("\"./my-dep\""))),
+        "type-only import './my-dep' must not be promoted to a runtime namespace import.\nOutput:\n{code}"
+    );
+
+    let factory_section =
+        code.split("ɵfac").nth(1).expect("Should have a factory definition (ɵfac)");
+    assert!(
+        factory_section.contains("ɵɵinvalidFactory()"),
+        "Injectable type-only DI param must produce `ɵɵinvalidFactory()`. Factory:\n{factory_section}"
+    );
+}

--- a/napi/angular-compiler/src/lib.rs
+++ b/napi/angular-compiler/src/lib.rs
@@ -2240,6 +2240,7 @@ fn compile_factory_impl(input: FactoryCompileInput) -> FactoryNapiCompileResult 
                         optional: dep.optional.unwrap_or(false),
                         self_: dep.self_.unwrap_or(false),
                         skip_self: dep.skip_self.unwrap_or(false),
+                        type_only_invalid: false,
                     });
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #288. A constructor parameter whose type annotation comes from a
type-only import (`import type { X }` or `import { type X }`) was being
promoted to a runtime DI token. The compiler emitted
`ɵɵdirectiveInject(i1.X)` and added a synthetic
`import * as i1 from './x'` for a module that TypeScript will erase —
crashing at runtime with "token must be defined" and breaking projects
that rely on `verbatimModuleSyntax` / `isolatedModules`.

## What changed

- Both DI-extraction paths (component path via
  `component/decorator.rs::extract_param_dependency` and the
  directive/pipe/injectable/ng_module path via
  `component/transform.rs::resolve_factory_dep_namespaces`) now check
  `ImportInfo.is_type_only` and tag the dep with a new
  `type_only_invalid` flag.
- `component/definition.rs::generate_constructor_factory` and
  `factory/compiler.rs::compile_factory_function` collapse the whole
  factory to `i0.ɵɵinvalidFactory()` when any dep carries the flag —
  matching Angular's reference behaviour
  (`ValueUnavailableKind.TYPE_ONLY_IMPORT`).
- The synthetic namespace import for the type-only module is
  suppressed, and `setClassMetadata` now emits `{type: undefined}`
  instead of `{type: i1.X}` for those parameters
  (`class_metadata/builders.rs::build_param_type_expression`).

## Test plan

- [x] 4 new regression tests in `integration_test.rs` cover:
  - `@Component` + `import type { MyService }`
  - `@Component` + inline `import { type MyService }`
  - `@Directive` + `import type`
  - `@Injectable` + `import type`
- [x] All 2549 workspace tests pass (`cargo test`)
- [x] `cargo fmt --all -- --check` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DI factory and metadata emission for a common TypeScript pattern; behavior now matches Angular reference but affects all decorated types with type-only ctor deps.
> 
> **Overview**
> Fixes **#288**: constructor parameters typed from **type-only imports** (`import type { X }` or `import { type X }`) are no longer turned into runtime DI tokens or synthetic `import * as iN` modules.
> 
> Dependency metadata gains a **`type_only_invalid`** flag when `ImportInfo.is_type_only` matches the token (component `extract_param_dependency` and `resolve_factory_dep_namespaces`). Any such dep forces the compiled factory to **`ɵɵinvalidFactory()`** instead of `new Class(ɵɵinject(...))`, and **`setClassMetadata`** omits runtime type values for those params (aligned with Angular’s `TYPE_ONLY_IMPORT`). **`create_invalid_factory_call`** is shared from the factory module for component definition generation.
> 
> Four integration tests cover component (declaration and inline `type` specifier), directive, and injectable cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433a78b3236768c6fa50ef985b78b5666e7baf24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->