### PR TITLE
feat(defer): emit lazy resolver and async metadata for @Component.deferredImports

### DIFF
--- a/crates/oxc_angular_compiler/src/class_metadata/compiler.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/compiler.rs
@@ -60,7 +60,7 @@ pub fn compile_component_class_metadata<'a>(
             // Has deferred dependencies - use setClassMetadataAsync
             let mut params = Vec::new_in(allocator);
             for dep in deps {
-                params.push(FnParam { name: dep.symbol_name.clone() });
+                params.push(FnParam { name: dep.param_name.clone() });
             }
             let resolver = compile_component_metadata_async_resolver(allocator, deps);
             internal_compile_set_class_metadata_async(allocator, metadata, params, resolver)
@@ -109,7 +109,7 @@ pub fn compile_component_metadata_async_resolver<'a>(
         inner_params.push(FnParam { name: Ident::from("m") });
 
         let prop_name =
-            if dep.is_default_import { Ident::from("default") } else { dep.symbol_name.clone() };
+            if dep.is_default_import { Ident::from("default") } else { dep.export_name.clone() };
 
         let inner_body = OutputExpression::ReadProp(Box::new_in(
             ReadPropExpr {

--- a/crates/oxc_angular_compiler/src/class_metadata/metadata.rs
+++ b/crates/oxc_angular_compiler/src/class_metadata/metadata.rs
@@ -31,11 +31,39 @@ pub struct R3ClassMetadata<'a> {
 
 /// Metadata for a deferred dependency in a component.
 ///
-/// Corresponds to Angular's `R3DeferPerComponentDependency` interface.
+/// Corresponds to Angular's `R3DeferPerComponentDependency` interface, but
+/// with the single `symbolName` field split in two so aliased imports can
+/// tree-shake correctly:
+///
+/// - `param_name` — the local binding (what the decorator metadata literal
+///   actually references). Used as the parameter name on the
+///   `setClassMetadataAsync` callback so the body's identifier references
+///   shadow the static import.
+/// - `export_name` — the name under which the symbol is exported from its
+///   source module. Used as the property read in the dynamic-import
+///   resolver chain (`m.<export_name>`).
+///
+/// Angular conflates both into one `symbolName` field (always the exported
+/// name), which leaves the static `import { Foo as Bar }` declaration pinned
+/// for aliased deferrable imports — the callback parameter `Foo` is bound
+/// but the body's `Bar` still references the outer scope. Splitting the
+/// fields lets the callback parameter shadow the alias and allows bundlers
+/// to drop the eager import.
 #[derive(Debug)]
 pub struct R3DeferPerComponentDependency<'a> {
-    /// The symbol name of the dependency.
-    pub symbol_name: Ident<'a>,
+    /// Local binding for the dependency in the current source file.
+    ///
+    /// Emitted as the `setClassMetadataAsync` callback parameter name so the
+    /// decorator metadata literal's references resolve to the callback
+    /// parameter rather than the outer static import.
+    pub param_name: Ident<'a>,
+
+    /// Name under which the dependency is exported from `import_path`.
+    ///
+    /// Emitted as the property read in the dynamic-import resolver
+    /// (`m.<export_name>`). For default imports the resolver substitutes
+    /// `m.default` based on `is_default_import` and this field is ignored.
+    pub export_name: Ident<'a>,
 
     /// The import path for the dependency.
     pub import_path: Ident<'a>,

--- a/crates/oxc_angular_compiler/src/component/decorator.rs
+++ b/crates/oxc_angular_compiler/src/component/decorator.rs
@@ -144,6 +144,15 @@ pub fn extract_component_metadata<'a>(
                     metadata.raw_imports =
                         convert_oxc_expression(allocator, &prop.value, source_text);
                 }
+                "deferredImports" => {
+                    // Symbols explicitly opted into lazy loading via `@defer`.
+                    // Mirrors Angular's `@Component.deferredImports` field; in
+                    // local compilation this is the only source of deferrable
+                    // dependencies (full compilation additionally derives them
+                    // from template usage of `imports: [...]`, which requires
+                    // cross-file selector info OXC doesn't have).
+                    metadata.deferred_imports = extract_identifier_array(allocator, &prop.value);
+                }
                 "exportAs" => {
                     // exportAs can be comma-separated: "foo, bar"
                     if let Some(export_as) =

--- a/crates/oxc_angular_compiler/src/component/defer_resolver.rs
+++ b/crates/oxc_angular_compiler/src/component/defer_resolver.rs
@@ -1,0 +1,218 @@
+//! Build the dependency-resolver function for `@defer` blocks.
+//!
+//! In Angular's local compilation mode the compiler emits a single
+//! per-component deferrable-dependencies function — a no-arg arrow that
+//! returns an array of dynamic `import()` calls resolving each lazy
+//! dependency. The runtime invokes it lazily, the first time a defer block
+//! triggers, so the deferred chunks can be code-split by the bundler.
+//!
+//! Example shape:
+//!
+//! ```js
+//! () => [
+//!   import('./lazy').then(m => m.LazyCmp),
+//!   import('./widget').then(m => m.HeavyWidget),
+//!   import('./default-export').then(m => m.default),
+//! ]
+//! ```
+//!
+//! This module produces that expression from the component's
+//! `@Component.deferredImports` array (mirrored as
+//! [`ComponentMetadata::deferred_imports`]) combined with the file-level
+//! import map. It is consumed by the main compile path in
+//! [`super::transform::compile_component_full`].
+//!
+//! ## Why `deferredImports`, not `imports`?
+//!
+//! Angular's full compilation mode also derives a deferrable set from
+//! `@Component.imports` by matching template selectors to imported
+//! directives/pipes/components (see `resolveAllDeferredDependencies` in
+//! `packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts`).
+//! That requires cross-file metadata OXC doesn't have — selectors live on
+//! the imported class, not on the import declaration. In local compilation
+//! (which OXC is — single file in, single file out) Angular falls back to
+//! the `deferredImports` field as the only safe source of deferrable
+//! symbols, and OXC does the same.
+
+use oxc_allocator::{Allocator, Box, Vec as OxcVec};
+use oxc_str::Ident;
+
+use crate::ast::r3::{R3DeferredBlock, R3Node, R3Visitor, visit_all};
+use crate::output::ast::{
+    ArrowFunctionBody, ArrowFunctionExpr, DynamicImportExpr, DynamicImportUrl, FnParam,
+    InvokeFunctionExpr, LiteralArrayExpr, OutputExpression, ReadPropExpr, ReadVarExpr,
+};
+
+use super::metadata::ComponentMetadata;
+use super::transform::ImportMap;
+
+/// Returns `true` if any `@defer` block exists anywhere in the template.
+///
+/// We need this so the compiler only generates a deferrable-dependencies
+/// function when it would actually be wired into a `ɵɵdefer` call — otherwise
+/// the resolver would be dead code.
+pub fn template_has_defer_block<'a>(nodes: &[R3Node<'a>]) -> bool {
+    struct DeferDetector {
+        found: bool,
+    }
+
+    impl<'a> R3Visitor<'a> for DeferDetector {
+        fn visit_deferred_block(&mut self, _block: &R3DeferredBlock<'a>) {
+            // No need to recurse: a single hit is enough.
+            self.found = true;
+        }
+    }
+
+    let mut visitor = DeferDetector { found: false };
+    visit_all(&mut visitor, nodes);
+    visitor.found
+}
+
+/// Build the deferrable-dependencies resolver expression from the component's
+/// `@Component.deferredImports` array.
+///
+/// For each local identifier in `metadata.deferred_imports` that resolves to
+/// an entry in `import_map`, emit one
+/// `import(<path>).then(m => m.<exportedName>)` entry. Returns `None` when the
+/// component has no `deferredImports` declared (no resolver to wire) — in
+/// that case callers leave `ɵɵdefer`'s resolver argument as `null`, matching
+/// Angular's behavior for a defer block with no explicit deferrable
+/// dependencies.
+///
+/// A deferred entry is silently skipped (with no compiler error) when:
+/// - the symbol isn't in the file's import map (it might be a local binding;
+///   Angular would have flagged this earlier, but we treat it as a no-op),
+/// - the import is a namespace import (`import * as ns`) — there is no
+///   single `m.X` to point at,
+/// - the import is type-only (erased at runtime).
+///
+/// Unlike eager `imports`, we do NOT filter by source module: Angular's
+/// `compileDeferResolverFunction` emits a dynamic `import(<path>)` for every
+/// entry the user lists, including bare specifiers like `@angular/material`.
+/// Filtering would silently drop intentional opt-ins.
+pub fn build_defer_resolver_expression<'a>(
+    allocator: &'a Allocator,
+    metadata: &ComponentMetadata<'a>,
+    import_map: &ImportMap<'a>,
+) -> Option<OutputExpression<'a>> {
+    if metadata.deferred_imports.is_empty() {
+        return None;
+    }
+
+    let mut entries = OxcVec::new_in(allocator);
+
+    for local_name in &metadata.deferred_imports {
+        let Some(info) = import_map.get(local_name) else { continue };
+
+        // Namespace imports (`import * as ns from 'x'`) cannot be turned into
+        // a single `m.X` reference, so skip them.
+        if !info.is_named_import {
+            continue;
+        }
+
+        // Type-only imports are erased at runtime — they have no concrete
+        // value to lazy-load.
+        if info.is_type_only {
+            continue;
+        }
+
+        // Choose the property to read off the loaded module:
+        // - Aliased named import (`import { Foo as Bar }`) → original `Foo`
+        // - Default import (`import D from 'x'`) → `default`
+        // - Plain named import (`import { Foo }`) → local name `Foo`
+        let export_name: Ident<'a> =
+            info.imported_name.clone().unwrap_or_else(|| local_name.clone());
+
+        entries.push(build_import_then_expression(
+            allocator,
+            info.source_module.clone(),
+            export_name,
+        ));
+    }
+
+    if entries.is_empty() {
+        return None;
+    }
+
+    // Wrap the array in a no-arg arrow function so the resolver is lazy.
+    let array_expr = OutputExpression::LiteralArray(Box::new_in(
+        LiteralArrayExpr { entries, source_span: None },
+        allocator,
+    ));
+    let arrow = OutputExpression::ArrowFunction(Box::new_in(
+        ArrowFunctionExpr {
+            params: OxcVec::new_in(allocator),
+            body: ArrowFunctionBody::Expression(Box::new_in(array_expr, allocator)),
+            source_span: None,
+        },
+        allocator,
+    ));
+    Some(arrow)
+}
+
+/// Build `import(<source>).then(m => m.<export_name>)`.
+fn build_import_then_expression<'a>(
+    allocator: &'a Allocator,
+    source: Ident<'a>,
+    export_name: Ident<'a>,
+) -> OutputExpression<'a> {
+    let dynamic_import = OutputExpression::DynamicImport(Box::new_in(
+        DynamicImportExpr {
+            url: DynamicImportUrl::String(source),
+            url_comment: None,
+            source_span: None,
+        },
+        allocator,
+    ));
+
+    // `m => m.<export_name>`
+    let m_ident = Ident::from("m");
+    let callback_body = OutputExpression::ReadProp(Box::new_in(
+        ReadPropExpr {
+            receiver: Box::new_in(
+                OutputExpression::ReadVar(Box::new_in(
+                    ReadVarExpr { name: m_ident.clone(), source_span: None },
+                    allocator,
+                )),
+                allocator,
+            ),
+            name: export_name,
+            optional: false,
+            source_span: None,
+        },
+        allocator,
+    ));
+    let mut params = OxcVec::with_capacity_in(1, allocator);
+    params.push(FnParam { name: m_ident });
+    let callback = OutputExpression::ArrowFunction(Box::new_in(
+        ArrowFunctionExpr {
+            params,
+            body: ArrowFunctionBody::Expression(Box::new_in(callback_body, allocator)),
+            source_span: None,
+        },
+        allocator,
+    ));
+
+    // `import(<source>).then(<callback>)`
+    let then_callee = OutputExpression::ReadProp(Box::new_in(
+        ReadPropExpr {
+            receiver: Box::new_in(dynamic_import, allocator),
+            name: Ident::from("then"),
+            optional: false,
+            source_span: None,
+        },
+        allocator,
+    ));
+    let mut args = OxcVec::with_capacity_in(1, allocator);
+    args.push(callback);
+    OutputExpression::InvokeFunction(Box::new_in(
+        InvokeFunctionExpr {
+            fn_expr: Box::new_in(then_callee, allocator),
+            args,
+            pure: false,
+            optional: false,
+            source_span: None,
+        },
+        allocator,
+    ))
+}

--- a/crates/oxc_angular_compiler/src/component/defer_resolver.rs
+++ b/crates/oxc_angular_compiler/src/component/defer_resolver.rs
@@ -34,14 +34,14 @@
 //! the `deferredImports` field as the only safe source of deferrable
 //! symbols, and OXC does the same.
 
-use oxc_allocator::{Allocator, Box, Vec as OxcVec};
-use oxc_str::Ident;
+use oxc_allocator::Allocator;
 
 use crate::ast::r3::{R3DeferredBlock, R3Node, R3Visitor, visit_all};
-use crate::output::ast::{
-    ArrowFunctionBody, ArrowFunctionExpr, DynamicImportExpr, DynamicImportUrl, FnParam,
-    InvokeFunctionExpr, LiteralArrayExpr, OutputExpression, ReadPropExpr, ReadVarExpr,
+use crate::class_metadata::{
+    R3DeferPerComponentDependency, compile_component_metadata_async_resolver,
 };
+use crate::output::ast::OutputExpression;
+use oxc_str::Ident;
 
 use super::metadata::ComponentMetadata;
 use super::transform::ImportMap;
@@ -68,6 +68,60 @@ pub fn template_has_defer_block<'a>(nodes: &[R3Node<'a>]) -> bool {
     visitor.found
 }
 
+/// Build the list of `R3DeferPerComponentDependency` describing the
+/// `@Component.deferredImports` entries, used to emit `setClassMetadataAsync`
+/// and the per-component `ɵɵdefer` resolver.
+///
+/// Each entry carries two names that serve distinct roles in the emitted
+/// output:
+///
+/// - `param_name` — the local binding from the source file (e.g. `Heavy` for
+///   `import { HeavyWidget as Heavy }`, `LazyCmp` for
+///   `import LazyCmp from './lazy'`). Used as the parameter name on the
+///   `setClassMetadataAsync` callback so the wrapped decorator metadata
+///   literal's identifier references shadow the outer static import,
+///   allowing bundlers to drop the eager declaration.
+/// - `export_name` — the name under which the symbol is exported from its
+///   source module (e.g. `HeavyWidget` or `default`). Used as the property
+///   read in the dynamic-import resolver chain (`m.<export_name>`). For
+///   default imports the resolver substitutes `m.default` based on
+///   `is_default_import`, so the value here is informational in that case.
+///
+/// Angular collapses both into a single `symbolName` field set to the
+/// exported name; that leaves the static `import { Foo as Bar }` pinned for
+/// aliased deferrable imports because the callback parameter (`Foo`) doesn't
+/// match the metadata body's reference (`Bar`). Splitting the fields here is
+/// a deliberate improvement on Angular's emission.
+///
+/// Entries for unresolved symbols, namespace imports, and type-only imports
+/// are skipped — they have no concrete runtime value to lazy-load and the
+/// resolver would silently misfire.
+pub(super) fn build_defer_per_component_deps<'a>(
+    allocator: &'a Allocator,
+    deferred_imports: &[Ident<'a>],
+    import_map: &ImportMap<'a>,
+) -> oxc_allocator::Vec<'a, R3DeferPerComponentDependency<'a>> {
+    let mut deps = oxc_allocator::Vec::new_in(allocator);
+    for local_name in deferred_imports {
+        let Some(info) = import_map.get(local_name) else { continue };
+        if !info.is_named_import || info.is_type_only {
+            continue;
+        }
+        let is_default_import = info.imported_name.as_deref() == Some("default");
+        // `export_name` is `info.imported_name` when present (aliased named
+        // imports or default imports), otherwise the local name (which
+        // equals the exported name for plain `import { Foo }`).
+        let export_name = info.imported_name.clone().unwrap_or_else(|| local_name.clone());
+        deps.push(R3DeferPerComponentDependency {
+            param_name: local_name.clone(),
+            export_name,
+            import_path: info.source_module.clone(),
+            is_default_import,
+        });
+    }
+    deps
+}
+
 /// Build the deferrable-dependencies resolver expression from the component's
 /// `@Component.deferredImports` array.
 ///
@@ -90,6 +144,11 @@ pub fn template_has_defer_block<'a>(nodes: &[R3Node<'a>]) -> bool {
 /// `compileDeferResolverFunction` emits a dynamic `import(<path>)` for every
 /// entry the user lists, including bare specifiers like `@angular/material`.
 /// Filtering would silently drop intentional opt-ins.
+///
+/// Shares the emission code path with `setClassMetadataAsync` via
+/// [`compile_component_metadata_async_resolver`] so both call sites stay in
+/// lockstep — the resolver wired into `ɵɵdefer(...)` is byte-equivalent to
+/// the one wired into `ɵsetClassMetadataAsync(...)`.
 pub fn build_defer_resolver_expression<'a>(
     allocator: &'a Allocator,
     metadata: &ComponentMetadata<'a>,
@@ -99,120 +158,10 @@ pub fn build_defer_resolver_expression<'a>(
         return None;
     }
 
-    let mut entries = OxcVec::new_in(allocator);
-
-    for local_name in &metadata.deferred_imports {
-        let Some(info) = import_map.get(local_name) else { continue };
-
-        // Namespace imports (`import * as ns from 'x'`) cannot be turned into
-        // a single `m.X` reference, so skip them.
-        if !info.is_named_import {
-            continue;
-        }
-
-        // Type-only imports are erased at runtime — they have no concrete
-        // value to lazy-load.
-        if info.is_type_only {
-            continue;
-        }
-
-        // Choose the property to read off the loaded module:
-        // - Aliased named import (`import { Foo as Bar }`) → original `Foo`
-        // - Default import (`import D from 'x'`) → `default`
-        // - Plain named import (`import { Foo }`) → local name `Foo`
-        let export_name: Ident<'a> =
-            info.imported_name.clone().unwrap_or_else(|| local_name.clone());
-
-        entries.push(build_import_then_expression(
-            allocator,
-            info.source_module.clone(),
-            export_name,
-        ));
-    }
-
-    if entries.is_empty() {
+    let deps = build_defer_per_component_deps(allocator, &metadata.deferred_imports, import_map);
+    if deps.is_empty() {
         return None;
     }
 
-    // Wrap the array in a no-arg arrow function so the resolver is lazy.
-    let array_expr = OutputExpression::LiteralArray(Box::new_in(
-        LiteralArrayExpr { entries, source_span: None },
-        allocator,
-    ));
-    let arrow = OutputExpression::ArrowFunction(Box::new_in(
-        ArrowFunctionExpr {
-            params: OxcVec::new_in(allocator),
-            body: ArrowFunctionBody::Expression(Box::new_in(array_expr, allocator)),
-            source_span: None,
-        },
-        allocator,
-    ));
-    Some(arrow)
-}
-
-/// Build `import(<source>).then(m => m.<export_name>)`.
-fn build_import_then_expression<'a>(
-    allocator: &'a Allocator,
-    source: Ident<'a>,
-    export_name: Ident<'a>,
-) -> OutputExpression<'a> {
-    let dynamic_import = OutputExpression::DynamicImport(Box::new_in(
-        DynamicImportExpr {
-            url: DynamicImportUrl::String(source),
-            url_comment: None,
-            source_span: None,
-        },
-        allocator,
-    ));
-
-    // `m => m.<export_name>`
-    let m_ident = Ident::from("m");
-    let callback_body = OutputExpression::ReadProp(Box::new_in(
-        ReadPropExpr {
-            receiver: Box::new_in(
-                OutputExpression::ReadVar(Box::new_in(
-                    ReadVarExpr { name: m_ident.clone(), source_span: None },
-                    allocator,
-                )),
-                allocator,
-            ),
-            name: export_name,
-            optional: false,
-            source_span: None,
-        },
-        allocator,
-    ));
-    let mut params = OxcVec::with_capacity_in(1, allocator);
-    params.push(FnParam { name: m_ident });
-    let callback = OutputExpression::ArrowFunction(Box::new_in(
-        ArrowFunctionExpr {
-            params,
-            body: ArrowFunctionBody::Expression(Box::new_in(callback_body, allocator)),
-            source_span: None,
-        },
-        allocator,
-    ));
-
-    // `import(<source>).then(<callback>)`
-    let then_callee = OutputExpression::ReadProp(Box::new_in(
-        ReadPropExpr {
-            receiver: Box::new_in(dynamic_import, allocator),
-            name: Ident::from("then"),
-            optional: false,
-            source_span: None,
-        },
-        allocator,
-    ));
-    let mut args = OxcVec::with_capacity_in(1, allocator);
-    args.push(callback);
-    OutputExpression::InvokeFunction(Box::new_in(
-        InvokeFunctionExpr {
-            fn_expr: Box::new_in(then_callee, allocator),
-            args,
-            pure: false,
-            optional: false,
-            source_span: None,
-        },
-        allocator,
-    ))
+    Some(compile_component_metadata_async_resolver(allocator, &deps))
 }

--- a/crates/oxc_angular_compiler/src/component/metadata.rs
+++ b/crates/oxc_angular_compiler/src/component/metadata.rs
@@ -256,6 +256,22 @@ pub struct ComponentMetadata<'a> {
     /// - A spread expression: `[...SHARED_IMPORTS, MyPipe]`
     pub raw_imports: Option<OutputExpression<'a>>,
 
+    /// Local identifiers from the `@Component.deferredImports` array.
+    ///
+    /// Each entry is a class binding the user explicitly opted into
+    /// lazy-loading via `@defer` blocks. The compiler wires them into the
+    /// per-component deferrable-dependencies resolver function emitted as
+    /// the third argument of `ɵɵdefer(...)`, and never includes them in the
+    /// eager dependency surface.
+    ///
+    /// Mirrors Angular's `analysis.explicitlyDeferredTypes` populated by
+    /// `collectExplicitlyDeferredSymbols` in
+    /// `packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts`.
+    /// Local compilation reads this field; full compilation additionally
+    /// derives candidates from template usage of `imports: [...]`, which
+    /// requires cross-file selector info OXC doesn't have.
+    pub deferred_imports: Vec<'a, Ident<'a>>,
+
     /// Animation triggers for the component.
     ///
     /// Corresponds to the `animations` property in `@Component`.
@@ -558,6 +574,7 @@ impl<'a> ComponentMetadata<'a> {
             declarations: Vec::new_in(allocator),
             declaration_list_emit_mode: DeclarationListEmitMode::default(),
             raw_imports: None,
+            deferred_imports: Vec::new_in(allocator),
             animations: None,
             schemas: Vec::new_in(allocator),
             is_signal: false,

--- a/crates/oxc_angular_compiler/src/component/mod.rs
+++ b/crates/oxc_angular_compiler/src/component/mod.rs
@@ -9,6 +9,7 @@
 #[cfg(feature = "cross_file_elision")]
 mod cross_file_elision;
 mod decorator;
+mod defer_resolver;
 mod definition;
 mod dependency;
 mod hoist;

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -596,18 +596,30 @@ pub fn build_import_map<'a>(
 /// Build the list of `R3DeferPerComponentDependency` describing the
 /// `@Component.deferredImports` entries, used to emit `setClassMetadataAsync`.
 ///
-/// Each entry carries the symbol's *original exported name* — the one the
-/// source module actually exports — plus the import path and a default-export
-/// flag. That name is used twice in the emitted output:
+/// Each entry carries a `symbol_name` that is used twice in the emitted
+/// output:
 ///
-/// 1. as the property read in the resolver (`m.HeavyWidget` rather than
-///    `m.Heavy`), and
-/// 2. as the parameter name on the `setClassMetadataAsync` callback.
+/// 1. as the parameter name on the `setClassMetadataAsync` callback — so the
+///    decorator object literal's identifier references resolve to the
+///    callback parameter rather than the static import, and
+/// 2. for non-default named imports, as the property read in the resolver
+///    (`m.HeavyWidget` rather than `m.Heavy`). Default imports use `m.default`
+///    via the `is_default_import` flag regardless of `symbol_name`.
 ///
 /// This mirrors Angular's `getExportedName`
-/// (`packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts:849`),
-/// which returns `decl.propertyName` for aliased imports and falls back to
-/// the local name otherwise.
+/// (`packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts:849`):
+///
+/// - For an `ImportSpecifier` (`import { Foo as Bar }`), it returns the
+///   `propertyName` (`Foo`) — the original exported name.
+/// - For any other declaration kind (default imports, namespace imports), it
+///   returns the local binding (`originalId.text`).
+///
+/// Default imports therefore *must* use the local binding as `symbol_name`:
+/// the literal string `"default"` is a JavaScript reserved word and would
+/// produce `(default) => { … }` — a `SyntaxError` — in the
+/// `setClassMetadataAsync` wrapper. The `m.default` property access is
+/// handled by the `is_default_import` branch in
+/// `compile_component_metadata_async_resolver`.
 ///
 /// Entries for unresolved symbols, namespace imports, and type-only imports
 /// are skipped — they have no concrete runtime value to lazy-load and the
@@ -624,9 +636,18 @@ fn build_defer_per_component_deps<'a>(
             continue;
         }
         let is_default_import = info.imported_name.as_deref() == Some("default");
-        // The original export name when it differs from the local binding
-        // (aliased or default import); otherwise the local name itself.
-        let symbol_name = info.imported_name.clone().unwrap_or_else(|| local_name.clone());
+        let symbol_name = if is_default_import {
+            // Default imports: the callback parameter must be a legal JS
+            // identifier, so fall back to the local binding (e.g. `LazyCmp`).
+            // The `m.default` property access is emitted separately via the
+            // `is_default_import` flag.
+            local_name.clone()
+        } else {
+            // Aliased named imports (`import { Foo as Bar }`) → original
+            // `Foo`. Plain named imports → local name (which equals the
+            // exported name).
+            info.imported_name.clone().unwrap_or_else(|| local_name.clone())
+        };
         deps.push(R3DeferPerComponentDependency {
             symbol_name,
             import_path: info.source_module.clone(),

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use oxc_allocator::{Allocator, Vec as OxcVec};
 use oxc_ast::ast::{
     Argument, Declaration, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
-    ImportOrExportKind, ObjectPropertyKind, PropertyKey, Statement,
+    ImportOrExportKind, ModuleExportName, ObjectPropertyKind, PropertyKey, Statement,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::Parser;
@@ -34,8 +34,9 @@ use super::namespace_registry::NamespaceRegistry;
 use crate::ast::expression::{BindingType, ParsedEventType};
 use crate::ast::r3::{R3BoundAttribute, R3BoundEvent, SecurityContext};
 use crate::class_metadata::{
-    R3ClassMetadata, build_ctor_params_metadata, build_decorator_metadata_array,
-    build_prop_decorators_metadata, compile_class_metadata,
+    R3ClassMetadata, R3DeferPerComponentDependency, build_ctor_params_metadata,
+    build_decorator_metadata_array, build_prop_decorators_metadata, compile_class_metadata,
+    compile_component_class_metadata,
 };
 use crate::directive::collect_string_consts;
 use crate::directive::{
@@ -421,6 +422,15 @@ pub struct ImportInfo<'a> {
     /// Type-only imports are erased at runtime and should not generate namespace
     /// imports for `setClassMetadata()` type references.
     pub is_type_only: bool,
+    /// Original exported name on the source module, when it differs from the
+    /// local binding name. Used to build correct `import('./mod').then(m => m.X)`
+    /// chains for `@defer` dependency resolvers.
+    ///
+    /// - `import { Foo }` → `None` (export name equals local name)
+    /// - `import { Foo as Bar }` → `Some("Foo")` (use original exported name)
+    /// - `import Foo from "./mod"` → `Some("default")` (default export)
+    /// - `import * as ns from "./mod"` → `None` (namespace, not deferrable)
+    pub imported_name: Option<Ident<'a>>,
 }
 
 /// Map from local identifier name to its import information.
@@ -454,6 +464,17 @@ pub type ImportMap<'a> = FxHashMap<Ident<'a>, ImportInfo<'a>>;
 ///   -> `is_named_import: true` (can use bare `DefaultService`)
 /// - Namespace imports: `import * as core from "@angular/core"`
 ///   -> `is_named_import: false` (need namespace prefix)
+/// Extract a `ModuleExportName` as a plain string slice when it's a textual
+/// name. Quoted-string export names (e.g., `import { "string-name" as foo }`)
+/// are not supported for deferrable resolution and return `None`.
+fn module_export_name_to_str<'a>(name: &ModuleExportName<'a>) -> Option<&'a str> {
+    match name {
+        ModuleExportName::IdentifierName(id) => Some(id.name.as_str()),
+        ModuleExportName::IdentifierReference(id) => Some(id.name.as_str()),
+        ModuleExportName::StringLiteral(_) => None,
+    }
+}
+
 pub fn build_import_map<'a>(
     allocator: &'a Allocator,
     program_body: &[Statement<'a>],
@@ -497,9 +518,23 @@ pub fn build_import_map<'a>(
                         .map(|resolved| Ident::from(allocator.alloc_str(resolved)))
                         .unwrap_or_else(|| default_source_module.clone().into());
 
+                    // Capture the original exported name when it differs from the
+                    // local binding (i.e., `import { Foo as Bar }`). This is used
+                    // when building `@defer` dependency resolvers so the dynamic
+                    // import chain references the original export, not the alias.
+                    let imported_export_name = module_export_name_to_str(&spec.imported);
+                    let imported_name = imported_export_name
+                        .filter(|exported| *exported != local_name.as_str())
+                        .map(|exported| Ident::from(allocator.alloc_str(exported)));
+
                     import_map.insert(
                         local_name,
-                        ImportInfo { source_module, is_named_import: true, is_type_only },
+                        ImportInfo {
+                            source_module,
+                            is_named_import: true,
+                            is_type_only,
+                            imported_name,
+                        },
                     );
                 }
                 ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
@@ -519,6 +554,10 @@ pub fn build_import_map<'a>(
                             source_module,
                             is_named_import: true,
                             is_type_only: decl_is_type_only,
+                            // Default imports always resolve to `m.default` in
+                            // dynamic-import chains, regardless of the local
+                            // binding name.
+                            imported_name: Some(Ident::from("default")),
                         },
                     );
                 }
@@ -539,6 +578,7 @@ pub fn build_import_map<'a>(
                             source_module,
                             is_named_import: false,
                             is_type_only: decl_is_type_only,
+                            imported_name: None,
                         },
                     );
                 }
@@ -553,6 +593,49 @@ pub fn build_import_map<'a>(
 ///
 /// Resolve namespace imports for factory dependency tokens.
 ///
+/// Build the list of `R3DeferPerComponentDependency` describing the
+/// `@Component.deferredImports` entries, used to emit `setClassMetadataAsync`.
+///
+/// Each entry carries the symbol's *original exported name* — the one the
+/// source module actually exports — plus the import path and a default-export
+/// flag. That name is used twice in the emitted output:
+///
+/// 1. as the property read in the resolver (`m.HeavyWidget` rather than
+///    `m.Heavy`), and
+/// 2. as the parameter name on the `setClassMetadataAsync` callback.
+///
+/// This mirrors Angular's `getExportedName`
+/// (`packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts:849`),
+/// which returns `decl.propertyName` for aliased imports and falls back to
+/// the local name otherwise.
+///
+/// Entries for unresolved symbols, namespace imports, and type-only imports
+/// are skipped — they have no concrete runtime value to lazy-load and the
+/// resolver would silently misfire.
+fn build_defer_per_component_deps<'a>(
+    allocator: &'a Allocator,
+    deferred_imports: &[Ident<'a>],
+    import_map: &ImportMap<'a>,
+) -> oxc_allocator::Vec<'a, R3DeferPerComponentDependency<'a>> {
+    let mut deps = oxc_allocator::Vec::new_in(allocator);
+    for local_name in deferred_imports {
+        let Some(info) = import_map.get(local_name) else { continue };
+        if !info.is_named_import || info.is_type_only {
+            continue;
+        }
+        let is_default_import = info.imported_name.as_deref() == Some("default");
+        // The original export name when it differs from the local binding
+        // (aliased or default import); otherwise the local name itself.
+        let symbol_name = info.imported_name.clone().unwrap_or_else(|| local_name.clone());
+        deps.push(R3DeferPerComponentDependency {
+            symbol_name,
+            import_path: info.source_module.clone(),
+            is_default_import,
+        });
+    }
+    deps
+}
+
 /// The import elision phase removes type-only imports (e.g., `import { Store } from '@ngrx/store'`)
 /// because constructor parameter types are considered type-only. However, the factory function
 /// needs to reference these types at runtime (e.g., `i0.ɵɵinject(Store)`).
@@ -2019,6 +2102,7 @@ pub fn transform_angular_file(
                         content_queries,
                         shared_pool_index,
                         &mut file_namespace_registry,
+                        &import_map,
                     ) {
                         Ok(compilation_result) => {
                             // Update the shared pool index for the next component
@@ -2142,9 +2226,46 @@ pub fn transform_angular_file(
                                         ),
                                     };
 
-                                    // Compile to the wrapped IIFE expression
-                                    let metadata_expr =
-                                        compile_class_metadata(allocator, &class_metadata);
+                                    // If the component opted into lazy loading via
+                                    // `@Component.deferredImports` AND actually uses
+                                    // `@defer` in its template, emit
+                                    // `ɵsetClassMetadataAsync` so the TestBed-facing
+                                    // metadata is built lazily inside a callback that
+                                    // receives the dynamically-imported classes as
+                                    // parameters. The decorator object literal still
+                                    // references symbols like `LazyCmp` by name, but
+                                    // those names resolve to the callback's parameters
+                                    // — there's no static reference to the import in
+                                    // the emitted code, so bundlers can tree-shake the
+                                    // `import { LazyCmp } from './lazy'` declaration in
+                                    // production builds (the sync `setClassMetadata`
+                                    // call is itself dev-only and gets dropped too).
+                                    //
+                                    // When the template has no `@defer` block we fall
+                                    // back to plain `setClassMetadata`: the resolver
+                                    // and async wrapper would never run, and emitting
+                                    // them would leave a stray `import(...)` in the
+                                    // output that defeats tree-shaking.
+                                    let deferred_deps: oxc_allocator::Vec<
+                                        R3DeferPerComponentDependency<'_>,
+                                    > = if compilation_result.has_defer_block {
+                                        build_defer_per_component_deps(
+                                            allocator,
+                                            &metadata.deferred_imports,
+                                            &import_map,
+                                        )
+                                    } else {
+                                        oxc_allocator::Vec::new_in(allocator)
+                                    };
+                                    let metadata_expr = if deferred_deps.is_empty() {
+                                        compile_class_metadata(allocator, &class_metadata)
+                                    } else {
+                                        compile_component_class_metadata(
+                                            allocator,
+                                            &class_metadata,
+                                            Some(deferred_deps.as_slice()),
+                                        )
+                                    };
                                     let metadata_js = emitter.emit_expression(&metadata_expr);
 
                                     if !decls_after_class.is_empty() {
@@ -2783,6 +2904,16 @@ struct FullCompilationResult {
 
     /// The ng-content selectors found in the template (e.g., `["*", ".header"]`).
     ng_content_selectors: Vec<String>,
+
+    /// `true` when the parsed template contains at least one `@defer` block.
+    ///
+    /// Used by the caller to gate `setClassMetadataAsync` emission: a component
+    /// can declare `deferredImports: [...]` without actually using `@defer` in
+    /// its template (e.g., during development before the block is wired up).
+    /// In that case Angular's runtime needs neither the lazy resolver nor the
+    /// async metadata callback, and emitting them would leave dead
+    /// `import(...)` calls in the output.
+    has_defer_block: bool,
 }
 
 /// Compile a component template and generate ɵcmp/ɵfac definitions.
@@ -2805,6 +2936,7 @@ fn compile_component_full<'a>(
     content_queries: OxcVec<'a, R3QueryMetadata<'a>>,
     pool_starting_index: u32,
     namespace_registry: &mut NamespaceRegistry<'a>,
+    import_map: &ImportMap<'a>,
 ) -> Result<FullCompilationResult, Vec<OxcDiagnostic>> {
     use oxc_allocator::FromIn;
 
@@ -2880,9 +3012,67 @@ fn compile_component_full<'a>(
     // Note: DomOnly mode is still used for host bindings (separate code path).
     let mode = TemplateCompilationMode::Full;
 
-    // Determine defer block emit mode based on JIT setting
-    // In JIT mode, use PerComponent mode since the compiler doesn't have full dependency info
-    let defer_block_deps_emit_mode = if options.jit {
+    // Reject overlap between `imports: [X]` and `deferredImports: [X]` —
+    // a symbol must be either eager OR deferrable, never both. Mirrors
+    // Angular's `validateNoImportOverlap` (handler.ts:2558+).
+    if !metadata.deferred_imports.is_empty() && !metadata.imports.is_empty() {
+        let eager: rustc_hash::FxHashSet<&str> =
+            metadata.imports.iter().map(|i| i.as_str()).collect();
+        for deferred in &metadata.deferred_imports {
+            if eager.contains(deferred.as_str()) {
+                diagnostics.push(OxcDiagnostic::error(format!(
+                    "`{}` is imported via both `@Component.imports` and `@Component.deferredImports`. \
+                     To fix this, make sure that dependencies are imported only once.",
+                    deferred.as_str()
+                )));
+            }
+        }
+        if !diagnostics.is_empty() {
+            return Err(diagnostics);
+        }
+    }
+
+    // Build the deferrable-dependencies resolver from
+    // `@Component.deferredImports`.
+    //
+    // OXC is a single-file (local) compiler, so we use Angular's PerComponent
+    // emit mode for defer dependencies: a single shared resolver function is
+    // generated from the component's `deferredImports: [...]` array and
+    // wired into every `ɵɵdefer(...)` call. The runtime invokes it lazily,
+    // the first time any defer block triggers.
+    //
+    // Issue: voidzero-dev/oxc-angular-compiler#289 — previously the resolver
+    // was omitted entirely, leaving `ɵɵdefer(...)` with no dependency
+    // argument and no `import(...)` calls in the output, so `@defer` did no
+    // code-splitting.
+    //
+    // Note: Angular's full compilation mode also derives deferrable symbols
+    // from `imports: [...]` by matching template selectors against imported
+    // directive classes (`resolveAllDeferredDependencies`). That needs
+    // cross-file metadata OXC doesn't have, so we follow Angular's local
+    // path and require explicit `deferredImports`.
+    // Computed once and reused below: the resolver decision and the eventual
+    // `setClassMetadataAsync` gate both depend on whether the template uses
+    // `@defer`.
+    let has_defer_block = super::defer_resolver::template_has_defer_block(&r3_result.nodes);
+
+    let defer_resolver_fn = if metadata.deferred_imports.is_empty() {
+        None
+    } else if has_defer_block {
+        super::defer_resolver::build_defer_resolver_expression(allocator, metadata, import_map)
+    } else {
+        // `deferredImports` declared but no `@defer` block — the resolver
+        // would be unused dead code. Leave it off.
+        None
+    };
+
+    // When we have a resolver, switch to PerComponent emit mode so the
+    // ingest stage threads `all_deferrable_deps_fn` into each `DeferOp`.
+    // Without a resolver, the existing PerBlock-vs-JIT behavior stays in
+    // place (and `all_deferrable_deps_fn = None`).
+    let defer_block_deps_emit_mode = if defer_resolver_fn.is_some() {
+        DeferBlockDepsEmitMode::PerComponent
+    } else if options.jit {
         DeferBlockDepsEmitMode::PerComponent
     } else {
         DeferBlockDepsEmitMode::PerBlock
@@ -2906,9 +3096,9 @@ fn compile_component_full<'a>(
         relative_template_path,
         enable_debug_locations,
         template_source: if enable_debug_locations { Some(template) } else { None },
-        // In PerComponent mode, this would be provided by the build tool
-        // For now, we don't have a way to pass it from NAPI, so it's None
-        all_deferrable_deps_fn: None,
+        // PerComponent mode: pass the shared resolver expression so the
+        // ingest stage attaches it to every defer block's create op.
+        all_deferrable_deps_fn: defer_resolver_fn,
         // Use the shared pool starting index to avoid duplicate constant names
         // when compiling multiple components in the same file
         pool_starting_index,
@@ -3119,6 +3309,7 @@ fn compile_component_full<'a>(
         class_debug_info_js,
         next_pool_index,
         ng_content_selectors,
+        has_defer_block,
     })
 }
 

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -593,59 +593,6 @@ pub fn build_import_map<'a>(
 ///
 /// Resolve namespace imports for factory dependency tokens.
 ///
-/// Build the list of `R3DeferPerComponentDependency` describing the
-/// `@Component.deferredImports` entries, used to emit `setClassMetadataAsync`.
-///
-/// Each entry carries two names that serve distinct roles in the emitted
-/// output:
-///
-/// - `param_name` — the local binding from the source file (e.g. `Heavy` for
-///   `import { HeavyWidget as Heavy }`, `LazyCmp` for
-///   `import LazyCmp from './lazy'`). Used as the parameter name on the
-///   `setClassMetadataAsync` callback so the wrapped decorator metadata
-///   literal's identifier references shadow the outer static import,
-///   allowing bundlers to drop the eager declaration.
-/// - `export_name` — the name under which the symbol is exported from its
-///   source module (e.g. `HeavyWidget` or `default`). Used as the property
-///   read in the dynamic-import resolver chain (`m.<export_name>`). For
-///   default imports the resolver substitutes `m.default` based on
-///   `is_default_import`, so the value here is informational in that case.
-///
-/// Angular collapses both into a single `symbolName` field set to the
-/// exported name; that leaves the static `import { Foo as Bar }` pinned for
-/// aliased deferrable imports because the callback parameter (`Foo`) doesn't
-/// match the metadata body's reference (`Bar`). Splitting the fields here is
-/// a deliberate improvement on Angular's emission.
-///
-/// Entries for unresolved symbols, namespace imports, and type-only imports
-/// are skipped — they have no concrete runtime value to lazy-load and the
-/// resolver would silently misfire.
-fn build_defer_per_component_deps<'a>(
-    allocator: &'a Allocator,
-    deferred_imports: &[Ident<'a>],
-    import_map: &ImportMap<'a>,
-) -> oxc_allocator::Vec<'a, R3DeferPerComponentDependency<'a>> {
-    let mut deps = oxc_allocator::Vec::new_in(allocator);
-    for local_name in deferred_imports {
-        let Some(info) = import_map.get(local_name) else { continue };
-        if !info.is_named_import || info.is_type_only {
-            continue;
-        }
-        let is_default_import = info.imported_name.as_deref() == Some("default");
-        // `export_name` is `info.imported_name` when present (aliased named
-        // imports or default imports), otherwise the local name (which
-        // equals the exported name for plain `import { Foo }`).
-        let export_name = info.imported_name.clone().unwrap_or_else(|| local_name.clone());
-        deps.push(R3DeferPerComponentDependency {
-            param_name: local_name.clone(),
-            export_name,
-            import_path: info.source_module.clone(),
-            is_default_import,
-        });
-    }
-    deps
-}
-
 /// The import elision phase removes type-only imports (e.g., `import { Store } from '@ngrx/store'`)
 /// because constructor parameter types are considered type-only. However, the factory function
 /// needs to reference these types at runtime (e.g., `i0.ɵɵinject(Store)`).
@@ -2259,7 +2206,7 @@ pub fn transform_angular_file(
                                     let deferred_deps: oxc_allocator::Vec<
                                         R3DeferPerComponentDependency<'_>,
                                     > = if compilation_result.has_defer_block {
-                                        build_defer_per_component_deps(
+                                        super::defer_resolver::build_defer_per_component_deps(
                                             allocator,
                                             &metadata.deferred_imports,
                                             &import_map,

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -596,30 +596,26 @@ pub fn build_import_map<'a>(
 /// Build the list of `R3DeferPerComponentDependency` describing the
 /// `@Component.deferredImports` entries, used to emit `setClassMetadataAsync`.
 ///
-/// Each entry carries a `symbol_name` that is used twice in the emitted
+/// Each entry carries two names that serve distinct roles in the emitted
 /// output:
 ///
-/// 1. as the parameter name on the `setClassMetadataAsync` callback — so the
-///    decorator object literal's identifier references resolve to the
-///    callback parameter rather than the static import, and
-/// 2. for non-default named imports, as the property read in the resolver
-///    (`m.HeavyWidget` rather than `m.Heavy`). Default imports use `m.default`
-///    via the `is_default_import` flag regardless of `symbol_name`.
+/// - `param_name` — the local binding from the source file (e.g. `Heavy` for
+///   `import { HeavyWidget as Heavy }`, `LazyCmp` for
+///   `import LazyCmp from './lazy'`). Used as the parameter name on the
+///   `setClassMetadataAsync` callback so the wrapped decorator metadata
+///   literal's identifier references shadow the outer static import,
+///   allowing bundlers to drop the eager declaration.
+/// - `export_name` — the name under which the symbol is exported from its
+///   source module (e.g. `HeavyWidget` or `default`). Used as the property
+///   read in the dynamic-import resolver chain (`m.<export_name>`). For
+///   default imports the resolver substitutes `m.default` based on
+///   `is_default_import`, so the value here is informational in that case.
 ///
-/// This mirrors Angular's `getExportedName`
-/// (`packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts:849`):
-///
-/// - For an `ImportSpecifier` (`import { Foo as Bar }`), it returns the
-///   `propertyName` (`Foo`) — the original exported name.
-/// - For any other declaration kind (default imports, namespace imports), it
-///   returns the local binding (`originalId.text`).
-///
-/// Default imports therefore *must* use the local binding as `symbol_name`:
-/// the literal string `"default"` is a JavaScript reserved word and would
-/// produce `(default) => { … }` — a `SyntaxError` — in the
-/// `setClassMetadataAsync` wrapper. The `m.default` property access is
-/// handled by the `is_default_import` branch in
-/// `compile_component_metadata_async_resolver`.
+/// Angular collapses both into a single `symbolName` field set to the
+/// exported name; that leaves the static `import { Foo as Bar }` pinned for
+/// aliased deferrable imports because the callback parameter (`Foo`) doesn't
+/// match the metadata body's reference (`Bar`). Splitting the fields here is
+/// a deliberate improvement on Angular's emission.
 ///
 /// Entries for unresolved symbols, namespace imports, and type-only imports
 /// are skipped — they have no concrete runtime value to lazy-load and the
@@ -636,20 +632,13 @@ fn build_defer_per_component_deps<'a>(
             continue;
         }
         let is_default_import = info.imported_name.as_deref() == Some("default");
-        let symbol_name = if is_default_import {
-            // Default imports: the callback parameter must be a legal JS
-            // identifier, so fall back to the local binding (e.g. `LazyCmp`).
-            // The `m.default` property access is emitted separately via the
-            // `is_default_import` flag.
-            local_name.clone()
-        } else {
-            // Aliased named imports (`import { Foo as Bar }`) → original
-            // `Foo`. Plain named imports → local name (which equals the
-            // exported name).
-            info.imported_name.clone().unwrap_or_else(|| local_name.clone())
-        };
+        // `export_name` is `info.imported_name` when present (aliased named
+        // imports or default imports), otherwise the local name (which
+        // equals the exported name for plain `import { Foo }`).
+        let export_name = info.imported_name.clone().unwrap_or_else(|| local_name.clone());
         deps.push(R3DeferPerComponentDependency {
-            symbol_name,
+            param_name: local_name.clone(),
+            export_name,
             import_path: info.source_module.clone(),
             is_default_import,
         });

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -464,17 +464,6 @@ pub type ImportMap<'a> = FxHashMap<Ident<'a>, ImportInfo<'a>>;
 ///   -> `is_named_import: true` (can use bare `DefaultService`)
 /// - Namespace imports: `import * as core from "@angular/core"`
 ///   -> `is_named_import: false` (need namespace prefix)
-/// Extract a `ModuleExportName` as a plain string slice when it's a textual
-/// name. Quoted-string export names (e.g., `import { "string-name" as foo }`)
-/// are not supported for deferrable resolution and return `None`.
-fn module_export_name_to_str<'a>(name: &ModuleExportName<'a>) -> Option<&'a str> {
-    match name {
-        ModuleExportName::IdentifierName(id) => Some(id.name.as_str()),
-        ModuleExportName::IdentifierReference(id) => Some(id.name.as_str()),
-        ModuleExportName::StringLiteral(_) => None,
-    }
-}
-
 pub fn build_import_map<'a>(
     allocator: &'a Allocator,
     program_body: &[Statement<'a>],
@@ -587,6 +576,17 @@ pub fn build_import_map<'a>(
     }
 
     import_map
+}
+
+/// Extract a `ModuleExportName` as a plain string slice when it's a textual
+/// name. Quoted-string export names (e.g., `import { "string-name" as foo }`)
+/// are not supported for deferrable resolution and return `None`.
+fn module_export_name_to_str<'a>(name: &ModuleExportName<'a>) -> Option<&'a str> {
+    match name {
+        ModuleExportName::IdentifierName(id) => Some(id.name.as_str()),
+        ModuleExportName::IdentifierReference(id) => Some(id.name.as_str()),
+        ModuleExportName::StringLiteral(_) => None,
+    }
 }
 
 /// Find the byte position (in the source) just after the last import statement.

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -738,6 +738,17 @@ export class Parent {}
         collapsed.contains(".then((m)=>m.default)") || collapsed.contains(".then(m=>m.default)"),
         "Default import must resolve to `m.default`. Output:\n{code}"
     );
+
+    // The `setClassMetadataAsync` callback parameter name must be a legal JS
+    // identifier — not the reserved word `default`. Use the local binding.
+    assert!(
+        !collapsed.contains("(default)=>") && !collapsed.contains("(default)=>"),
+        "Default-import callback parameter must not be the reserved word `default`. Output:\n{code}"
+    );
+    assert!(
+        collapsed.contains("(LazyCmp)=>"),
+        "Default-import callback parameter must use the local binding name `LazyCmp`. Output:\n{code}"
+    );
 }
 
 /// Components without `@defer` blocks must not generate a resolver function

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -591,6 +591,255 @@ fn test_defer_on_viewport() {
     insta::assert_snapshot!("defer_on_viewport", js);
 }
 
+/// Reproduces voidzero-dev/oxc-angular-compiler#289 (aligned with Angular's
+/// local-compilation behavior): a `@defer` block on a component whose lazy
+/// dependency is declared in the `@Component.deferredImports` array must emit
+/// a deferrable-dependencies resolver — a no-arg arrow returning an array of
+/// dynamic `import()` calls — wired in as the third argument of
+/// `ɵɵdefer(...)`. Previously the resolver argument was omitted entirely and
+/// no `import('./lazy')` appeared anywhere in the output.
+#[test]
+fn test_defer_emits_dependency_resolver_from_deferred_imports() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+import { LazyCmp } from './lazy';
+
+@Component({
+    selector: 'app-parent',
+    deferredImports: [LazyCmp],
+    template: '@defer { <app-lazy/> }',
+    standalone: true,
+})
+export class Parent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "parent.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    // The output must contain a dynamic import of the lazy module.
+    assert!(
+        code.contains("import(\"./lazy\")") || code.contains("import('./lazy')"),
+        "Expected a dynamic `import('./lazy')` for the deferred dependency. Output:\n{code}"
+    );
+
+    // The dynamic import should be followed by `.then(...)` with a callback
+    // that reads `m.LazyCmp` (the original / local export name). Exact
+    // whitespace and parenthesization of the arrow params is up to the
+    // emitter.
+    let collapsed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(
+        collapsed.contains(".then((m)=>m.LazyCmp)") || collapsed.contains(".then(m=>m.LazyCmp)"),
+        "Expected `.then(m => m.LazyCmp)` chain after dynamic import. Output:\n{code}"
+    );
+
+    // The resolver expression must be wired into `ɵɵdefer(...)` as a non-null
+    // third argument.
+    assert!(
+        code.contains("ɵɵdefer(1,0,() =>[import(\"./lazy\")")
+            || code.contains("ɵɵdefer(1,0,()=>[import(\"./lazy\")"),
+        "ɵɵdefer's 3rd argument (resolverFn) must be the deferrable-deps arrow function. Output:\n{code}"
+    );
+
+    // The deferred symbol must NOT appear in the eager dependencies factory.
+    // (When the component has only `deferredImports` and no `imports`, the
+    // `dependencies` field is omitted entirely.)
+    assert!(
+        !code.contains("ɵɵgetComponentDepsFactory(Parent,[LazyCmp]"),
+        "Deferred symbol must not appear in the eager `ɵɵgetComponentDepsFactory` array. Output:\n{code}"
+    );
+
+    // `setClassMetadataAsync` (not the sync `setClassMetadata`) should be
+    // emitted so the TestBed-facing metadata is built lazily — the deferred
+    // symbol is reached through the async callback's parameter, not a
+    // static import reference.
+    assert!(
+        code.contains("setClassMetadataAsync"),
+        "Components with `deferredImports` should emit `setClassMetadataAsync`. Output:\n{code}"
+    );
+}
+
+/// Aliased imports must use the original exported name in `m.X`, not the
+/// local alias.
+#[test]
+fn test_defer_dependency_resolver_uses_original_export_name_for_aliases() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+import { HeavyWidget as Heavy } from './widget';
+
+@Component({
+    selector: 'app-parent',
+    deferredImports: [Heavy],
+    template: '@defer { <app-heavy/> }',
+    standalone: true,
+})
+export class Parent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "parent.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    assert!(
+        code.contains("import(\"./widget\")") || code.contains("import('./widget')"),
+        "Expected dynamic `import('./widget')`. Output:\n{code}"
+    );
+
+    // The chain must resolve `m.HeavyWidget` (the original export name), not
+    // `m.Heavy` (the local alias).
+    let collapsed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(
+        collapsed.contains(".then((m)=>m.HeavyWidget)")
+            || collapsed.contains(".then(m=>m.HeavyWidget)"),
+        "Expected `.then(m => m.HeavyWidget)` using the original export name. Output:\n{code}"
+    );
+    assert!(
+        !collapsed.contains("m.Heavy)") && !collapsed.contains("m.Heavy,"),
+        "Aliased import must not resolve to the local alias `Heavy`. Output:\n{code}"
+    );
+}
+
+/// Default imports must use `m.default` in the resolver chain.
+#[test]
+fn test_defer_dependency_resolver_uses_default_for_default_imports() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+import LazyCmp from './lazy-default';
+
+@Component({
+    selector: 'app-parent',
+    deferredImports: [LazyCmp],
+    template: '@defer { <app-lazy/> }',
+    standalone: true,
+})
+export class Parent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "parent.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+
+    assert!(
+        code.contains("import(\"./lazy-default\")") || code.contains("import('./lazy-default')"),
+        "Expected dynamic `import('./lazy-default')`. Output:\n{code}"
+    );
+
+    let collapsed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(
+        collapsed.contains(".then((m)=>m.default)") || collapsed.contains(".then(m=>m.default)"),
+        "Default import must resolve to `m.default`. Output:\n{code}"
+    );
+}
+
+/// Components without `@defer` blocks must not generate a resolver function
+/// (regression guard so we don't accidentally produce dead lazy-loading code).
+#[test]
+fn test_no_defer_block_skips_dependency_resolver() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+import { ChildCmp } from './child';
+
+@Component({
+    selector: 'app-parent',
+    deferredImports: [ChildCmp],
+    template: '<app-child/>',
+    standalone: true,
+})
+export class Parent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "parent.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+    assert!(
+        !code.contains("import(\"./child\")") && !code.contains("import('./child')"),
+        "Components without @defer must not emit dynamic imports. Output:\n{code}"
+    );
+}
+
+/// When the user lists a symbol only in `@Component.imports`, OXC must NOT
+/// auto-detect it as deferrable (that's the full-compilation behavior, which
+/// needs cross-file selector info OXC doesn't have). Issue #289's original
+/// repro form (`imports: [LazyCmp]` with `@defer`) therefore emits no
+/// resolver — the user must move the symbol to `deferredImports`.
+#[test]
+fn test_defer_with_only_imports_does_not_auto_detect() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+import { LazyCmp } from './lazy';
+
+@Component({
+    selector: 'app-parent',
+    imports: [LazyCmp],
+    template: '@defer { <app-lazy/> }',
+    standalone: true,
+})
+export class Parent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "parent.component.ts", source, None, None);
+
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    let code = &result.code;
+    // `imports: [LazyCmp]` alone must remain eager — no dynamic import emitted.
+    assert!(
+        !code.contains("import(\"./lazy\")") && !code.contains("import('./lazy')"),
+        "Symbols declared only in `imports` (not `deferredImports`) must not be lazy-loaded in local compilation. Output:\n{code}"
+    );
+}
+
+/// Matches Angular's `validateNoImportOverlap` (handler.ts:2558+): a symbol
+/// listed in both `imports` and `deferredImports` is an error — each
+/// dependency must have a single, unambiguous role.
+#[test]
+fn test_defer_overlap_between_imports_and_deferred_imports_is_diagnostic() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+import { Mixed } from './mixed';
+
+@Component({
+    selector: 'app-parent',
+    imports: [Mixed],
+    deferredImports: [Mixed],
+    template: '@defer { <app-mixed/> }',
+    standalone: true,
+})
+export class Parent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "parent.component.ts", source, None, None);
+
+    assert!(
+        result.has_errors(),
+        "Symbol used in both `imports` and `deferredImports` must yield a diagnostic. Output:\n{}",
+        result.code
+    );
+    let any_overlap_msg = result.diagnostics.iter().any(|d| {
+        let s = format!("{d}");
+        s.contains("`@Component.imports`") && s.contains("`@Component.deferredImports`")
+    });
+    assert!(
+        any_overlap_msg,
+        "Diagnostic should mention both `@Component.imports` and `@Component.deferredImports`. Got: {:?}",
+        result.diagnostics
+    );
+}
+
 #[test]
 #[should_panic(
     expected = "Cannot specify additional `hydrate` triggers if `hydrate never` is present"

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -703,6 +703,20 @@ export class Parent {}
         !collapsed.contains("m.Heavy)") && !collapsed.contains("m.Heavy,"),
         "Aliased import must not resolve to the local alias `Heavy`. Output:\n{code}"
     );
+
+    // The `setClassMetadataAsync` callback parameter must use the *local*
+    // binding so the decorator metadata body's `Heavy` reference shadows the
+    // outer static import — letting bundlers drop the eager declaration.
+    // Angular emits `(HeavyWidget) =>` here and leaves the static import
+    // pinned; we diverge to enable tree-shaking.
+    assert!(
+        collapsed.contains("(Heavy)=>"),
+        "Expected `(Heavy) =>` callback parameter (local binding shadows static import). Output:\n{code}"
+    );
+    assert!(
+        !collapsed.contains("(HeavyWidget)=>"),
+        "Callback parameter must NOT be the original export name `HeavyWidget` (would leave the static import pinned). Output:\n{code}"
+    );
 }
 
 /// Default imports must use `m.default` in the resolver chain.


### PR DESCRIPTION
## Summary

- Wire `@Component.deferredImports` into a per-component deferrable-deps resolver (`() => [import('./x').then(m => m.X)]`) threaded into every `ɵɵdefer(...)` call, and emit `ɵsetClassMetadataAsync` so TestBed-facing metadata loads through the same dynamic imports. Matches Angular's local-compilation path.
- Resolver uses the **original** exported name (Angular's `getExportedName`): aliased imports (`import { HeavyWidget as Heavy }`) emit `m.HeavyWidget`, default imports emit `m.default`.
- The resolver and `setClassMetadataAsync` are emitted **only when the template actually has an `@defer` block** — declaring `deferredImports` without a block keeps the eager `setClassMetadata` path and emits no dead `import(...)` calls.
- Diagnostic for symbols listed in both `imports` and `deferredImports` (mirrors `validateNoImportOverlap`).
- Symbols in `imports` alone are **not** auto-detected as deferrable — cross-file selector resolution isn't available in local mode, so users must opt in via `deferredImports`.

Closes voidzero-dev/oxc-angular-compiler#289.

## Test plan

- [x] `cargo test -p oxc_angular_compiler` passes (1044+ integration tests, plus 5 new defer-resolver tests)
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all -- --check` clean
- [x] Aliased imports resolve via original export name (`m.HeavyWidget`, not `m.Heavy`)
- [x] Default imports resolve via `m.default`
- [x] No `import(...)` emitted when `deferredImports` set but template has no `@defer`
- [x] Symbol listed only in `imports` is not auto-deferred
- [x] Overlap between `imports` and `deferredImports` raises a diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches component transform, template ingest, and dev metadata emission paths; behavior is gated on `@defer` presence but incorrect resolver wiring could break lazy loading or bundler tree-shaking.
> 
> **Overview**
> Adds **local-compilation `@defer` support** driven by `@Component.deferredImports`: the compiler parses that decorator field, builds a shared per-component resolver (`() => [import(...).then(m => m.X)]`), passes it into template ingest as `ɵɵdefer`’s third argument, and switches defer-deps emit mode to **PerComponent** when a resolver exists.
> 
> **Import map** now records `imported_name` (export vs local binding) so dynamic imports use the real export (`m.HeavyWidget`, `m.default`) while **`setClassMetadataAsync`** callback params use the **local** name (`Heavy`)—splitting `param_name` / `export_name` on `R3DeferPerComponentDependency` so aliased defer imports can tree-shake better than Angular’s single `symbolName`.
> 
> **Gating & validation:** resolver and async metadata run only if the template actually contains `@defer`; overlap between `imports` and `deferredImports` is a compile error; symbols listed only in `imports` are not auto-deferred. Integration tests cover resolver wiring, aliases, defaults, and diagnostics (#289).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd17d93b635f1fe74b07abd99b80b433dcce652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->