### PR TITLE
fix(transform): report templateUrl/styleUrls in result.dependencies

### DIFF
--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -2021,6 +2021,16 @@ pub fn transform_angular_file(
                 Some(source),
                 &string_consts,
             ) {
+                // Track external resource dependencies before resolution so build tools
+                // still learn which sibling files to watch when the resource isn't in
+                // `resolved_resources` or compilation fails downstream.
+                if let Some(template_url) = &metadata.template_url {
+                    result.dependencies.push(template_url.to_string());
+                }
+                for style_url in &metadata.style_urls {
+                    result.dependencies.push(style_url.to_string());
+                }
+
                 // 3. Resolve external styles and merge into metadata
                 resolve_styles(allocator, &mut metadata, resolved_resources);
 
@@ -2255,14 +2265,6 @@ pub fn transform_angular_file(
                                 ),
                                 class.body.span.end,
                             ));
-
-                            // Track external dependencies
-                            if let Some(template_url) = &metadata.template_url {
-                                result.dependencies.push(template_url.to_string());
-                            }
-                            for style_url in &metadata.style_urls {
-                                result.dependencies.push(style_url.to_string());
-                            }
 
                             // Generate .d.ts type declaration for this component
                             let type_argument_count = class

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -13083,6 +13083,118 @@ export class MyService {
     );
 }
 
+/// Regression for https://github.com/voidzero-dev/oxc-angular-compiler/issues/291.
+///
+/// `transformAngularFile` must surface external `templateUrl` / `styleUrls`
+/// paths in `result.dependencies` so build tools (the Vite plugin in
+/// particular) can register them as watch dependencies.
+#[test]
+fn test_resource_dependencies_reported_when_resolved() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-x',
+    templateUrl: './x.html',
+    styleUrls: ['./x.css', './shared.css'],
+    standalone: true,
+})
+export class XComponent {}
+"#;
+
+    let mut templates = std::collections::HashMap::new();
+    templates.insert("./x.html".to_string(), "<div>x</div>".to_string());
+    let mut styles = std::collections::HashMap::new();
+    styles.insert("./x.css".to_string(), vec![".x{color:red}".to_string()]);
+    styles.insert("./shared.css".to_string(), vec![".shared{}".to_string()]);
+    let resources = ResolvedResources { templates, styles };
+
+    let result =
+        transform_angular_file(&allocator, "x.component.ts", source, None, Some(&resources));
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    assert!(
+        result.dependencies.contains(&"./x.html".to_string()),
+        "templateUrl should appear in dependencies, got: {:?}",
+        result.dependencies
+    );
+    assert!(
+        result.dependencies.contains(&"./x.css".to_string()),
+        "styleUrl ./x.css should appear in dependencies, got: {:?}",
+        result.dependencies
+    );
+    assert!(
+        result.dependencies.contains(&"./shared.css".to_string()),
+        "styleUrl ./shared.css should appear in dependencies, got: {:?}",
+        result.dependencies
+    );
+}
+
+/// Regression for https://github.com/voidzero-dev/oxc-angular-compiler/issues/291.
+///
+/// External resource paths must be reported in `result.dependencies` even when
+/// no `ResolvedResources` map is supplied. Build tools call the compiler from
+/// their loader, and they need to know which sibling files to watch *before*
+/// they can pre-load and supply the resource contents. Returning an empty
+/// `dependencies` list when `resolvedResources` is `None` silently breaks HMR.
+#[test]
+fn test_resource_dependencies_reported_without_resolved_resources() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-x',
+    templateUrl: './x.html',
+    styleUrls: ['./x.css', './shared.css'],
+    standalone: true,
+})
+export class XComponent {}
+"#;
+
+    // No ResolvedResources passed — mirrors the path build tools hit on the
+    // first transform pass before they've discovered the sibling files.
+    let result = transform_angular_file(&allocator, "x.component.ts", source, None, None);
+
+    assert!(
+        result.dependencies.contains(&"./x.html".to_string()),
+        "templateUrl must be reported in dependencies even when unresolved, got: {:?}",
+        result.dependencies
+    );
+    assert!(
+        result.dependencies.contains(&"./x.css".to_string())
+            && result.dependencies.contains(&"./shared.css".to_string()),
+        "styleUrls must be reported in dependencies even when unresolved, got: {:?}",
+        result.dependencies
+    );
+}
+
+/// styleUrls must be tracked even when the component uses an inline
+/// `template:` string. styles and templates are independent resource axes.
+#[test]
+fn test_inline_template_with_external_styles_reports_style_dependencies() {
+    let allocator = Allocator::default();
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-x',
+    template: '<div>inline</div>',
+    styleUrl: './x.css',
+    standalone: true,
+})
+export class XComponent {}
+"#;
+
+    let result = transform_angular_file(&allocator, "x.component.ts", source, None, None);
+    assert!(
+        result.dependencies.contains(&"./x.css".to_string()),
+        "styleUrl alongside an inline template must still appear in dependencies, got: {:?}",
+        result.dependencies
+    );
+}
+
 /// Regression for https://github.com/voidzero-dev/oxc-angular-compiler/issues/290.
 ///
 /// A `@Component` template like `<div><span></div>` used to compile silently —


### PR DESCRIPTION
## Summary

- Closes #291 — external `templateUrl` / `styleUrls` paths now appear in `result.dependencies` so the Vite plugin (and any other watch-mode build tool) can register them as watch dependencies.
- Previously these URLs were only pushed from inside the `Ok(compile_component_full(...))` branch, which is only reached when `resolve_template` returns `Some`. With no `resolvedResources` (or a missing entry, or a downstream compile failure), the declared URLs silently disappeared and edits to sibling `.html` / `.css` files missed rebuilds.
- Fix hoists the dependency-tracking block to right after metadata extraction so URLs are recorded as soon as they're declared, regardless of resolution outcome. The duplicate inside the `Ok` branch is removed.

## Test plan

- [x] `cargo test` — 2562 passed, 0 failed (3 new tests)
- [x] New integration tests in `tests/integration_test.rs`:
  - `test_resource_dependencies_reported_when_resolved` — happy path with `ResolvedResources` (locks the existing contract).
  - `test_resource_dependencies_reported_without_resolved_resources` — the exact repro from the issue: `templateUrl: './x.html'` + no resources → previously `[]`, now contains the URL and styleUrls.
  - `test_inline_template_with_external_styles_reports_style_dependencies` — `template:` inline plus `styleUrl:` external still reports the style dependency.
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to when dependency paths are collected; covered by new integration tests and does not alter compile output semantics.
> 
> **Overview**
> External **`templateUrl`** and **`styleUrls`** paths are now added to **`result.dependencies`** immediately after component metadata is extracted, instead of only when full template compilation succeeds.
> 
> That lets watch-mode tooling (e.g. the Vite plugin) register sibling `.html` / `.css` files on the first transform pass, even when **`ResolvedResources`** is missing, entries are absent, or downstream compile fails. The duplicate push inside the successful **`compile_component_full`** path was removed.
> 
> Three integration tests lock in resolved resources, unresolved resources, and inline template + external **`styleUrl`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1983fc8cec70a5d0fbc1b02ad1c5d79388a89116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->