### PR TITLE
fix(jit): lower signal initializer APIs to synthesized propDecorators

### DIFF
--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -1203,12 +1203,26 @@ fn classify_initializer_api(callee: &Expression<'_>) -> Option<InitializerApiKin
     }
 }
 
+/// Namespace alias under which `@angular/core` is imported when JIT synthesis needs
+/// to reference decorator names that the user didn't import (e.g. `Input` for a
+/// `@Component` that uses `input()` but didn't import the capital-letter decorator).
+///
+/// Matches ngc's `createSyntheticAngularCoreDecoratorAccess`, which emits
+/// `i0.Input` / `i0.Output` / etc. backed by `import * as i0 from "@angular/core"`.
+/// Without this prefixing, the synthesized `static propDecorators` would reference
+/// an undefined identifier and throw `ReferenceError` at module-evaluation time.
+pub(crate) const JIT_ANGULAR_CORE_NS: &str = "i0";
+
 /// Inspect a property initializer; if it matches a recognized signal initializer API,
 /// return the synthesized `propDecorators` entries that JIT runtime needs.
 ///
 /// `existing` contains the names of explicit field decorators already present on the
 /// property (e.g. `Input`, `Output`); we skip synthesis when the user-authored decorator
 /// already covers the binding (matches upstream behavior — explicit decorator wins).
+///
+/// Synthesized decorator names are namespace-prefixed (e.g. `i0.Input`) — see
+/// [`JIT_ANGULAR_CORE_NS`]. The caller is responsible for emitting the matching
+/// `import * as i0 from "@angular/core"` when any synthesis occurred.
 fn synthesize_signal_api_decorators(
     source: &str,
     initializer: &Expression<'_>,
@@ -1234,7 +1248,10 @@ fn synthesize_signal_api_decorators(
                 alias = escape_js_string(&alias),
                 required = required,
             );
-            std::vec::Vec::from([JitParamDecorator { name: "Input".to_string(), args: Some(args) }])
+            std::vec::Vec::from([JitParamDecorator {
+                name: format!("{JIT_ANGULAR_CORE_NS}.Input"),
+                args: Some(args),
+            }])
         }
         InitializerApiKind::Output | InitializerApiKind::OutputFromObservable => {
             if existing.contains("Output") {
@@ -1247,7 +1264,7 @@ fn synthesize_signal_api_decorators(
                 .unwrap_or_else(|| field_name.to_string());
             let args = format!("\"{}\"", escape_js_string(&alias));
             std::vec::Vec::from([JitParamDecorator {
-                name: "Output".to_string(),
+                name: format!("{JIT_ANGULAR_CORE_NS}.Output"),
                 args: Some(args),
             }])
         }
@@ -1268,8 +1285,14 @@ fn synthesize_signal_api_decorators(
             );
             let output_args = format!("\"{}Change\"", escape_js_string(&alias));
             std::vec::Vec::from([
-                JitParamDecorator { name: "Input".to_string(), args: Some(input_args) },
-                JitParamDecorator { name: "Output".to_string(), args: Some(output_args) },
+                JitParamDecorator {
+                    name: format!("{JIT_ANGULAR_CORE_NS}.Input"),
+                    args: Some(input_args),
+                },
+                JitParamDecorator {
+                    name: format!("{JIT_ANGULAR_CORE_NS}.Output"),
+                    args: Some(output_args),
+                },
             ])
         }
         InitializerApiKind::ViewChild
@@ -1310,11 +1333,23 @@ fn synthesize_signal_api_decorators(
             };
             let args = format!("{locator_text}, {options_text}");
             std::vec::Vec::from([JitParamDecorator {
-                name: decorator_name.to_string(),
+                name: format!("{JIT_ANGULAR_CORE_NS}.{decorator_name}"),
                 args: Some(args),
             }])
         }
     }
+}
+
+/// Returns `true` when any field of any JIT class has a synthesized decorator
+/// (signal API lowering) that references the `@angular/core` namespace. Used to
+/// gate the emission of `import * as i0 from "@angular/core"`.
+fn jit_classes_need_angular_core_namespace(jit_classes: &[JitClassInfo]) -> bool {
+    let prefix = format!("{JIT_ANGULAR_CORE_NS}.");
+    jit_classes.iter().any(|info| {
+        info.member_decorators
+            .iter()
+            .any(|m| m.decorators.iter().any(|d| d.name.starts_with(&prefix)))
+    })
 }
 
 /// Pull a string option (e.g. `alias`) from the object literal at `args[options_index]`.
@@ -1894,9 +1929,15 @@ fn transform_angular_file_jit(
     // 4. Build edits
     let mut edits: std::vec::Vec<Edit> = std::vec::Vec::new();
 
-    // Build the additional imports text (tslib + resource imports)
+    // Build the additional imports text (tslib + resource imports + Angular namespace
+    // when signal-API lowering synthesized decorators that need to resolve to
+    // `i0.Input`/`i0.Output`/etc. at runtime).
     let mut additional_imports = String::new();
     additional_imports.push_str("import { __decorate } from \"tslib\";\n");
+    if jit_classes_need_angular_core_namespace(&jit_classes) {
+        additional_imports
+            .push_str(&format!("import * as {JIT_ANGULAR_CORE_NS} from \"@angular/core\";\n"));
+    }
     for (import_name, specifier) in &resource_imports {
         additional_imports.push_str(&format!("import {} from \"{}\";\n", import_name, specifier));
     }

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -1013,14 +1013,14 @@ fn extract_all_jit_member_decorators(
     let mut non_angular_members: std::vec::Vec<JitNonAngularMemberDecorator> = std::vec::Vec::new();
 
     for element in &class.body.body {
-        let (member_name, is_static, is_property, decorators) = match element {
+        let (member_name, is_static, is_property, decorators, initializer) = match element {
             ClassElement::PropertyDefinition(prop) => {
                 let name = match &prop.key {
                     PropertyKey::StaticIdentifier(id) => id.name.to_string(),
                     PropertyKey::StringLiteral(s) => s.value.to_string(),
                     _ => continue,
                 };
-                (name, prop.r#static, true, &prop.decorators)
+                (name, prop.r#static, true, &prop.decorators, prop.value.as_ref())
             }
             ClassElement::MethodDefinition(method) => {
                 if method.kind == MethodDefinitionKind::Constructor {
@@ -1031,7 +1031,7 @@ fn extract_all_jit_member_decorators(
                     PropertyKey::StringLiteral(s) => s.value.to_string(),
                     _ => continue,
                 };
-                (name, method.r#static, false, &method.decorators)
+                (name, method.r#static, false, &method.decorators, None)
             }
             ClassElement::AccessorProperty(accessor) => {
                 let name = match &accessor.key {
@@ -1039,13 +1039,15 @@ fn extract_all_jit_member_decorators(
                     PropertyKey::StringLiteral(s) => s.value.to_string(),
                     _ => continue,
                 };
-                (name, accessor.r#static, false, &accessor.decorators)
+                (name, accessor.r#static, false, &accessor.decorators, None)
             }
             _ => continue,
         };
 
         let mut angular_decs: std::vec::Vec<JitParamDecorator> = std::vec::Vec::new();
         let mut non_angular_texts: std::vec::Vec<String> = std::vec::Vec::new();
+        let mut explicit_field_decorators: rustc_hash::FxHashSet<String> =
+            rustc_hash::FxHashSet::default();
 
         for decorator in decorators {
             let (dec_name, call_args) = match &decorator.expression {
@@ -1070,6 +1072,7 @@ fn extract_all_jit_member_decorators(
 
             if ANGULAR_FIELD_DECORATORS.contains(&dec_name.as_str()) {
                 // Angular field decorator → goes into propDecorators
+                explicit_field_decorators.insert(dec_name.clone());
                 angular_decs.push(JitParamDecorator { name: dec_name, args: call_args });
             } else if !ANGULAR_DECORATOR_NAMES.contains(&dec_name.as_str()) {
                 // Non-Angular decorator → goes into __decorate() call
@@ -1079,6 +1082,21 @@ fn extract_all_jit_member_decorators(
             }
             // Angular non-field decorators (e.g. @Inject on a member) are silently dropped
             // since they have no meaningful effect on members.
+        }
+
+        // Signal initializer-API lowering: synthesize @Input / @Output / @ViewChild / etc.
+        // decorators from `input()`, `output()`, `model()`, `viewChild*()`, `contentChild*()`
+        // initializers so the runtime JIT facade can discover them via `propDecorators`.
+        // Mirrors `packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/`.
+        // When an explicit matching decorator already exists, the explicit one wins.
+        if let Some(init) = initializer {
+            let synthesized = synthesize_signal_api_decorators(
+                source,
+                init,
+                &member_name,
+                &explicit_field_decorators,
+            );
+            angular_decs.extend(synthesized);
         }
 
         if !angular_decs.is_empty() {
@@ -1099,6 +1117,233 @@ fn extract_all_jit_member_decorators(
     }
 
     (angular_members, non_angular_members)
+}
+
+/// Strip `as`/`satisfies`/parenthesized wrappers around an initializer expression,
+/// mirroring ngc's `tryParseInitializerApi` (e.g. `x = input(0) as any`, `x = (input(0))`).
+fn unwrap_jit_initializer<'a, 'b>(expr: &'b Expression<'a>) -> &'b Expression<'a> {
+    match expr {
+        Expression::TSAsExpression(e) => unwrap_jit_initializer(&e.expression),
+        Expression::TSSatisfiesExpression(e) => unwrap_jit_initializer(&e.expression),
+        Expression::ParenthesizedExpression(e) => unwrap_jit_initializer(&e.expression),
+        _ => expr,
+    }
+}
+
+/// Recognized initializer API kinds. Used to dispatch synthesis.
+#[derive(Debug, Clone, Copy)]
+enum InitializerApiKind {
+    Input,
+    InputRequired,
+    Output,
+    OutputFromObservable,
+    Model,
+    ModelRequired,
+    ViewChild,
+    ViewChildRequired,
+    ViewChildren,
+    ContentChild,
+    ContentChildRequired,
+    ContentChildren,
+}
+
+/// Identify which initializer API a call expression represents.
+///
+/// Handles three call shapes:
+/// - bare identifier: `input(...)`, `output(...)`
+/// - `.required` member: `input.required(...)`, `model.required(...)`
+/// - namespaced: `core.input(...)`, `core.viewChild.required(...)`
+fn classify_initializer_api(callee: &Expression<'_>) -> Option<InitializerApiKind> {
+    fn match_name(name: &str) -> Option<InitializerApiKind> {
+        match name {
+            "input" => Some(InitializerApiKind::Input),
+            "output" => Some(InitializerApiKind::Output),
+            "outputFromObservable" => Some(InitializerApiKind::OutputFromObservable),
+            "model" => Some(InitializerApiKind::Model),
+            "viewChild" => Some(InitializerApiKind::ViewChild),
+            "viewChildren" => Some(InitializerApiKind::ViewChildren),
+            "contentChild" => Some(InitializerApiKind::ContentChild),
+            "contentChildren" => Some(InitializerApiKind::ContentChildren),
+            _ => None,
+        }
+    }
+    fn required_variant(base: InitializerApiKind) -> Option<InitializerApiKind> {
+        match base {
+            InitializerApiKind::Input => Some(InitializerApiKind::InputRequired),
+            InitializerApiKind::Model => Some(InitializerApiKind::ModelRequired),
+            InitializerApiKind::ViewChild => Some(InitializerApiKind::ViewChildRequired),
+            InitializerApiKind::ContentChild => Some(InitializerApiKind::ContentChildRequired),
+            _ => None,
+        }
+    }
+
+    match callee {
+        Expression::Identifier(id) => match_name(id.name.as_str()),
+        Expression::StaticMemberExpression(member) => {
+            // `<base>.required` — find the underlying base API and promote it.
+            if member.property.name == "required" {
+                let base = match &member.object {
+                    Expression::Identifier(id) => match_name(id.name.as_str())?,
+                    Expression::StaticMemberExpression(inner) => {
+                        // Namespaced: `core.input.required`
+                        match_name(inner.property.name.as_str())?
+                    }
+                    _ => return None,
+                };
+                required_variant(base)
+            } else {
+                // Namespaced: `core.input(...)`. The outer property *is* the function name.
+                match &member.object {
+                    Expression::Identifier(_) => match_name(member.property.name.as_str()),
+                    _ => None,
+                }
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Inspect a property initializer; if it matches a recognized signal initializer API,
+/// return the synthesized `propDecorators` entries that JIT runtime needs.
+///
+/// `existing` contains the names of explicit field decorators already present on the
+/// property (e.g. `Input`, `Output`); we skip synthesis when the user-authored decorator
+/// already covers the binding (matches upstream behavior — explicit decorator wins).
+fn synthesize_signal_api_decorators(
+    source: &str,
+    initializer: &Expression<'_>,
+    field_name: &str,
+    existing: &rustc_hash::FxHashSet<String>,
+) -> std::vec::Vec<JitParamDecorator> {
+    let unwrapped = unwrap_jit_initializer(initializer);
+    let Expression::CallExpression(call) = unwrapped else { return std::vec::Vec::new() };
+    let Some(kind) = classify_initializer_api(&call.callee) else { return std::vec::Vec::new() };
+
+    match kind {
+        InitializerApiKind::Input | InitializerApiKind::InputRequired => {
+            if existing.contains("Input") {
+                return std::vec::Vec::new();
+            }
+            let required = matches!(kind, InitializerApiKind::InputRequired);
+            // input(initial, options?) → options is args[1]; input.required(options?) → args[0].
+            let options_index = if required { 0 } else { 1 };
+            let alias = extract_string_option(call, options_index, "alias")
+                .unwrap_or_else(|| field_name.to_string());
+            let args = format!(
+                "{{ isSignal: true, alias: \"{alias}\", required: {required}, transform: undefined }}",
+                alias = escape_js_string(&alias),
+                required = required,
+            );
+            std::vec::Vec::from([JitParamDecorator { name: "Input".to_string(), args: Some(args) }])
+        }
+        InitializerApiKind::Output | InitializerApiKind::OutputFromObservable => {
+            if existing.contains("Output") {
+                return std::vec::Vec::new();
+            }
+            // output(options?) → args[0]; outputFromObservable(source, options?) → args[1].
+            let options_index =
+                if matches!(kind, InitializerApiKind::OutputFromObservable) { 1 } else { 0 };
+            let alias = extract_string_option(call, options_index, "alias")
+                .unwrap_or_else(|| field_name.to_string());
+            let args = format!("\"{}\"", escape_js_string(&alias));
+            std::vec::Vec::from([JitParamDecorator {
+                name: "Output".to_string(),
+                args: Some(args),
+            }])
+        }
+        InitializerApiKind::Model | InitializerApiKind::ModelRequired => {
+            // model() is two bindings — block if either @Input or @Output is already present.
+            if existing.contains("Input") || existing.contains("Output") {
+                return std::vec::Vec::new();
+            }
+            let required = matches!(kind, InitializerApiKind::ModelRequired);
+            // Same arg layout as input.
+            let options_index = if required { 0 } else { 1 };
+            let alias = extract_string_option(call, options_index, "alias")
+                .unwrap_or_else(|| field_name.to_string());
+            let input_args = format!(
+                "{{ isSignal: true, alias: \"{alias}\", required: {required}, transform: undefined }}",
+                alias = escape_js_string(&alias),
+                required = required,
+            );
+            let output_args = format!("\"{}Change\"", escape_js_string(&alias));
+            std::vec::Vec::from([
+                JitParamDecorator { name: "Input".to_string(), args: Some(input_args) },
+                JitParamDecorator { name: "Output".to_string(), args: Some(output_args) },
+            ])
+        }
+        InitializerApiKind::ViewChild
+        | InitializerApiKind::ViewChildRequired
+        | InitializerApiKind::ViewChildren
+        | InitializerApiKind::ContentChild
+        | InitializerApiKind::ContentChildRequired
+        | InitializerApiKind::ContentChildren => {
+            // Any existing query decorator blocks all query synthesis on this field.
+            const QUERY_DECS: &[&str] =
+                &["ViewChild", "ViewChildren", "ContentChild", "ContentChildren"];
+            if QUERY_DECS.iter().any(|d| existing.contains(*d)) {
+                return std::vec::Vec::new();
+            }
+            let decorator_name = match kind {
+                InitializerApiKind::ViewChild | InitializerApiKind::ViewChildRequired => "ViewChild",
+                InitializerApiKind::ViewChildren => "ViewChildren",
+                InitializerApiKind::ContentChild | InitializerApiKind::ContentChildRequired => {
+                    "ContentChild"
+                }
+                InitializerApiKind::ContentChildren => "ContentChildren",
+                _ => unreachable!(),
+            };
+            // Mirror ngc query lowering: positional args carry over; isSignal is folded into
+            // the options object (spreading the existing options if present).
+            let Some(locator_arg) = call.arguments.first() else { return std::vec::Vec::new() };
+            let locator_text =
+                source[locator_arg.span().start as usize..locator_arg.span().end as usize].to_string();
+            let options_text = if let Some(opts_arg) = call.arguments.get(1) {
+                let opts_src =
+                    &source[opts_arg.span().start as usize..opts_arg.span().end as usize];
+                format!("{{ ...{}, isSignal: true }}", opts_src)
+            } else {
+                "{ isSignal: true }".to_string()
+            };
+            let args = format!("{locator_text}, {options_text}");
+            std::vec::Vec::from([JitParamDecorator {
+                name: decorator_name.to_string(),
+                args: Some(args),
+            }])
+        }
+    }
+}
+
+/// Pull a string option (e.g. `alias`) from the object literal at `args[options_index]`.
+/// Returns `None` if the argument isn't an object literal or the option is missing/non-string.
+fn extract_string_option(
+    call: &oxc_ast::ast::CallExpression<'_>,
+    options_index: usize,
+    option_name: &str,
+) -> Option<String> {
+    let arg = call.arguments.get(options_index)?;
+    let Argument::ObjectExpression(obj) = arg else { return None };
+    for prop in &obj.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop else { continue };
+        let key_matches = match &prop.key {
+            PropertyKey::StaticIdentifier(id) => id.name.as_str() == option_name,
+            PropertyKey::StringLiteral(s) => s.value.as_str() == option_name,
+            _ => false,
+        };
+        if !key_matches {
+            continue;
+        }
+        if let Expression::StringLiteral(s) = &prop.value {
+            return Some(s.value.to_string());
+        }
+    }
+    None
+}
+
+/// Minimal JS-string escape for values embedded in synthesized propDecorator text.
+/// Property names are TS identifiers or string literals, so only `\` and `"` matter.
+fn escape_js_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// Build the propDecorators static property text for JIT member decorator metadata.

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -1285,7 +1285,9 @@ fn synthesize_signal_api_decorators(
                 return std::vec::Vec::new();
             }
             let decorator_name = match kind {
-                InitializerApiKind::ViewChild | InitializerApiKind::ViewChildRequired => "ViewChild",
+                InitializerApiKind::ViewChild | InitializerApiKind::ViewChildRequired => {
+                    "ViewChild"
+                }
                 InitializerApiKind::ViewChildren => "ViewChildren",
                 InitializerApiKind::ContentChild | InitializerApiKind::ContentChildRequired => {
                     "ContentChild"
@@ -1296,8 +1298,9 @@ fn synthesize_signal_api_decorators(
             // Mirror ngc query lowering: positional args carry over; isSignal is folded into
             // the options object (spreading the existing options if present).
             let Some(locator_arg) = call.arguments.first() else { return std::vec::Vec::new() };
-            let locator_text =
-                source[locator_arg.span().start as usize..locator_arg.span().end as usize].to_string();
+            let locator_text = source
+                [locator_arg.span().start as usize..locator_arg.span().end as usize]
+                .to_string();
             let options_text = if let Some(opts_arg) = call.arguments.get(1) {
                 let opts_src =
                     &source[opts_arg.span().start as usize..opts_arg.span().end as usize];

--- a/crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs
+++ b/crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs
@@ -36,10 +36,7 @@ fn component(body: &str, imports: &str) -> String {
 #[test]
 fn input_initializer_emits_synthesized_input_prop_decorator() {
     let out = compile_jit(&component("  readonly value = input(0);", "input"));
-    assert!(
-        out.contains("propDecorators"),
-        "JIT output should emit propDecorators. Got:\n{out}"
-    );
+    assert!(out.contains("propDecorators"), "JIT output should emit propDecorators. Got:\n{out}");
     assert!(out.contains("value:"), "field name should be a propDecorators key. Got:\n{out}");
     assert!(out.contains("type: Input"), "synthesized @Input missing. Got:\n{out}");
     assert!(out.contains("isSignal: true"), "isSignal flag missing. Got:\n{out}");
@@ -51,15 +48,16 @@ fn input_initializer_emits_synthesized_input_prop_decorator() {
 fn input_required_marks_required_true() {
     let out = compile_jit(&component("  readonly value = input.required<string>();", "input"));
     assert!(out.contains("type: Input"), "Got:\n{out}");
-    assert!(out.contains("required: true"), "input.required() should set required: true. Got:\n{out}");
+    assert!(
+        out.contains("required: true"),
+        "input.required() should set required: true. Got:\n{out}"
+    );
 }
 
 #[test]
 fn input_with_alias_option_uses_provided_alias() {
-    let out = compile_jit(&component(
-        "  readonly value = input(0, { alias: 'publicName' });",
-        "input",
-    ));
+    let out =
+        compile_jit(&component("  readonly value = input(0, { alias: 'publicName' });", "input"));
     assert!(out.contains("alias: \"publicName\""), "alias from options not honored. Got:\n{out}");
 }
 
@@ -115,13 +113,19 @@ fn model_synthesizes_input_and_output_pair() {
     assert!(out.contains("type: Input"), "@Input half of model() missing. Got:\n{out}");
     assert!(out.contains("type: Output"), "@Output half of model() missing. Got:\n{out}");
     // Output alias is `<input>Change` (matches ngc behavior).
-    assert!(out.contains("\"valueChange\""), "model's output alias `<name>Change` missing. Got:\n{out}");
+    assert!(
+        out.contains("\"valueChange\""),
+        "model's output alias `<name>Change` missing. Got:\n{out}"
+    );
 }
 
 #[test]
 fn model_required_propagates_required_to_input() {
     let out = compile_jit(&component("  readonly value = model.required<string>();", "model"));
-    assert!(out.contains("required: true"), "model.required() should set Input.required. Got:\n{out}");
+    assert!(
+        out.contains("required: true"),
+        "model.required() should set Input.required. Got:\n{out}"
+    );
 }
 
 #[test]

--- a/crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs
+++ b/crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs
@@ -34,11 +34,46 @@ fn component(body: &str, imports: &str) -> String {
 }
 
 #[test]
+fn synthesized_decorators_resolve_against_angular_core_namespace_import() {
+    // Regression for the Codex P1 review on PR #319: a typical signal component
+    // imports only the lowercase functions (`input`, `output`, …) from
+    // `@angular/core`, not the capital-letter decorators. The synthesized
+    // `propDecorators` therefore must reference an Angular namespace alias and
+    // the JIT path must emit the matching `import * as i0 from "@angular/core"`,
+    // otherwise the module throws `ReferenceError: Input is not defined` while
+    // evaluating the class — before Angular's JIT facade ever runs.
+    let out = compile_jit(&component("  readonly value = input(0);", "input"));
+    assert!(
+        out.contains("import * as i0 from \"@angular/core\""),
+        "JIT path must inject the namespace import when synthesis occurred. Got:\n{out}"
+    );
+    assert!(
+        out.contains("type: i0.Input"),
+        "synthesized decorator must use the namespace alias. Got:\n{out}"
+    );
+}
+
+#[test]
+fn namespace_import_skipped_when_no_synthesis_needed() {
+    // No initializer-API usage at all → no synthesis → no namespace import.
+    // Adding it unconditionally would pollute every JIT-compiled file.
+    let out = compile_jit(
+        "import { Component } from '@angular/core';\n\
+         @Component({ selector: 'c', template: '', standalone: true })\n\
+         export class C { plain = 1; }\n",
+    );
+    assert!(
+        !out.contains("import * as i0 from \"@angular/core\""),
+        "namespace import should be skipped when no decorators were synthesized. Got:\n{out}"
+    );
+}
+
+#[test]
 fn input_initializer_emits_synthesized_input_prop_decorator() {
     let out = compile_jit(&component("  readonly value = input(0);", "input"));
     assert!(out.contains("propDecorators"), "JIT output should emit propDecorators. Got:\n{out}");
     assert!(out.contains("value:"), "field name should be a propDecorators key. Got:\n{out}");
-    assert!(out.contains("type: Input"), "synthesized @Input missing. Got:\n{out}");
+    assert!(out.contains("type: i0.Input"), "synthesized @Input missing. Got:\n{out}");
     assert!(out.contains("isSignal: true"), "isSignal flag missing. Got:\n{out}");
     assert!(out.contains("required: false"), "required: false missing. Got:\n{out}");
     assert!(out.contains("alias: \"value\""), "default alias = field name missing. Got:\n{out}");
@@ -47,7 +82,7 @@ fn input_initializer_emits_synthesized_input_prop_decorator() {
 #[test]
 fn input_required_marks_required_true() {
     let out = compile_jit(&component("  readonly value = input.required<string>();", "input"));
-    assert!(out.contains("type: Input"), "Got:\n{out}");
+    assert!(out.contains("type: i0.Input"), "Got:\n{out}");
     assert!(
         out.contains("required: true"),
         "input.required() should set required: true. Got:\n{out}"
@@ -66,7 +101,9 @@ fn explicit_input_decorator_blocks_input_synthesis() {
     // The user explicitly chose @Input — the decorator wins, no synthesized version
     // should appear (mirrors upstream signalInputsTransform's early return).
     let out = compile_jit(&component("  @Input() value = input(0);", "input, Input"));
-    // The explicit @Input decorator survives via the existing propDecorators path…
+    // The explicit @Input decorator survives via the existing propDecorators path.
+    // Explicit decorators reference the user's bare `Input` import (no namespace
+    // prefix); only synthesized decorators are namespace-prefixed.
     assert!(out.contains("type: Input"), "explicit @Input lost. Got:\n{out}");
     // …but the synthesized entry must NOT add isSignal. If both ran, isSignal would
     // appear in the args. Its absence proves the synthesis was skipped.
@@ -79,7 +116,7 @@ fn explicit_input_decorator_blocks_input_synthesis() {
 #[test]
 fn output_initializer_emits_synthesized_output_prop_decorator() {
     let out = compile_jit(&component("  readonly clicked = output<void>();", "output"));
-    assert!(out.contains("type: Output"), "synthesized @Output missing. Got:\n{out}");
+    assert!(out.contains("type: i0.Output"), "synthesized @Output missing. Got:\n{out}");
     // Default alias is the field name.
     assert!(out.contains("\"clicked\""), "default alias missing. Got:\n{out}");
 }
@@ -110,8 +147,8 @@ fn output_from_observable_options_live_in_args_1() {
 fn model_synthesizes_input_and_output_pair() {
     let out = compile_jit(&component("  readonly value = model(0);", "model"));
     // Both decorators on the same field.
-    assert!(out.contains("type: Input"), "@Input half of model() missing. Got:\n{out}");
-    assert!(out.contains("type: Output"), "@Output half of model() missing. Got:\n{out}");
+    assert!(out.contains("type: i0.Input"), "@Input half of model() missing. Got:\n{out}");
+    assert!(out.contains("type: i0.Output"), "@Output half of model() missing. Got:\n{out}");
     // Output alias is `<input>Change` (matches ngc behavior).
     assert!(
         out.contains("\"valueChange\""),
@@ -134,7 +171,7 @@ fn view_child_emits_synthesized_view_child_with_is_signal() {
         "  readonly el = viewChild<ElementRef>('ref');",
         "viewChild, ElementRef",
     ));
-    assert!(out.contains("type: ViewChild"), "synthesized @ViewChild missing. Got:\n{out}");
+    assert!(out.contains("type: i0.ViewChild"), "synthesized @ViewChild missing. Got:\n{out}");
     assert!(out.contains("isSignal: true"), "isSignal flag missing on query. Got:\n{out}");
     // OXC's TS stripper normalizes single-quoted string literals to double-quoted, so
     // assert against the post-strip form. The locator text just needs to survive.
@@ -157,7 +194,7 @@ fn view_children_emits_view_children_decorator() {
         "  readonly els = viewChildren<ElementRef>('ref');",
         "viewChildren, ElementRef",
     ));
-    assert!(out.contains("type: ViewChildren"), "Got:\n{out}");
+    assert!(out.contains("type: i0.ViewChildren"), "Got:\n{out}");
 }
 
 #[test]
@@ -167,7 +204,7 @@ fn content_child_required_emits_content_child() {
         "contentChild, ElementRef",
     ));
     // .required() variant maps to the same decorator name (ContentChild), with isSignal.
-    assert!(out.contains("type: ContentChild"), "Got:\n{out}");
+    assert!(out.contains("type: i0.ContentChild"), "Got:\n{out}");
     assert!(out.contains("isSignal: true"), "Got:\n{out}");
 }
 
@@ -179,6 +216,8 @@ fn explicit_view_child_decorator_blocks_query_synthesis() {
         "  @ViewChild('r') r = viewChild<ElementRef>('r');",
         "viewChild, ViewChild, ElementRef",
     ));
+    // Explicit @ViewChild references the user's bare `ViewChild` import (no namespace
+    // prefix); only synthesized decorators are namespace-prefixed.
     assert!(out.contains("type: ViewChild"), "explicit @ViewChild lost. Got:\n{out}");
     assert!(
         !out.contains("isSignal"),

--- a/crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs
+++ b/crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs
@@ -1,0 +1,183 @@
+//! JIT downlevel parity for signal initializer APIs.
+//!
+//! When `jit: true`, OXC must synthesize `@Input`/`@Output`/`@ViewChild`/etc.
+//! `propDecorators` entries for fields initialized via `input()`, `output()`,
+//! `model()`, `viewChild()`, `viewChildren()`, `contentChild()`,
+//! `contentChildren()`. The runtime JIT facade
+//! (`compileComponent`/`compileDirective` in `@angular/compiler`) discovers
+//! inputs/outputs/queries via decorator metadata only — never via field
+//! initializers — so without lowering, a JIT-compiled signal component has
+//! no inputs/outputs/queries at runtime.
+//!
+//! Mirrors `packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/`.
+//! Issue #312.
+
+use oxc_allocator::Allocator;
+use oxc_angular_compiler::{TransformOptions as ComponentTransformOptions, transform_angular_file};
+
+/// Compile in JIT mode and return the emitted code.
+fn compile_jit(source: &str) -> String {
+    let allocator = Allocator::default();
+    let options = ComponentTransformOptions { jit: true, ..Default::default() };
+    let result =
+        transform_angular_file(&allocator, "test.component.ts", source, Some(&options), None);
+    assert!(!result.has_errors(), "compile errored: {:?}", result.diagnostics);
+    result.code
+}
+
+fn component(body: &str, imports: &str) -> String {
+    format!(
+        "import {{ Component, {imports} }} from '@angular/core';\n\n\
+         @Component({{ selector: 'c', template: '', standalone: true }})\n\
+         export class C {{\n{body}\n}}\n"
+    )
+}
+
+#[test]
+fn input_initializer_emits_synthesized_input_prop_decorator() {
+    let out = compile_jit(&component("  readonly value = input(0);", "input"));
+    assert!(
+        out.contains("propDecorators"),
+        "JIT output should emit propDecorators. Got:\n{out}"
+    );
+    assert!(out.contains("value:"), "field name should be a propDecorators key. Got:\n{out}");
+    assert!(out.contains("type: Input"), "synthesized @Input missing. Got:\n{out}");
+    assert!(out.contains("isSignal: true"), "isSignal flag missing. Got:\n{out}");
+    assert!(out.contains("required: false"), "required: false missing. Got:\n{out}");
+    assert!(out.contains("alias: \"value\""), "default alias = field name missing. Got:\n{out}");
+}
+
+#[test]
+fn input_required_marks_required_true() {
+    let out = compile_jit(&component("  readonly value = input.required<string>();", "input"));
+    assert!(out.contains("type: Input"), "Got:\n{out}");
+    assert!(out.contains("required: true"), "input.required() should set required: true. Got:\n{out}");
+}
+
+#[test]
+fn input_with_alias_option_uses_provided_alias() {
+    let out = compile_jit(&component(
+        "  readonly value = input(0, { alias: 'publicName' });",
+        "input",
+    ));
+    assert!(out.contains("alias: \"publicName\""), "alias from options not honored. Got:\n{out}");
+}
+
+#[test]
+fn explicit_input_decorator_blocks_input_synthesis() {
+    // The user explicitly chose @Input — the decorator wins, no synthesized version
+    // should appear (mirrors upstream signalInputsTransform's early return).
+    let out = compile_jit(&component("  @Input() value = input(0);", "input, Input"));
+    // The explicit @Input decorator survives via the existing propDecorators path…
+    assert!(out.contains("type: Input"), "explicit @Input lost. Got:\n{out}");
+    // …but the synthesized entry must NOT add isSignal. If both ran, isSignal would
+    // appear in the args. Its absence proves the synthesis was skipped.
+    assert!(
+        !out.contains("isSignal"),
+        "synthesis must be skipped when explicit @Input is present. Got:\n{out}"
+    );
+}
+
+#[test]
+fn output_initializer_emits_synthesized_output_prop_decorator() {
+    let out = compile_jit(&component("  readonly clicked = output<void>();", "output"));
+    assert!(out.contains("type: Output"), "synthesized @Output missing. Got:\n{out}");
+    // Default alias is the field name.
+    assert!(out.contains("\"clicked\""), "default alias missing. Got:\n{out}");
+}
+
+#[test]
+fn output_with_alias_option() {
+    let out = compile_jit(&component(
+        "  readonly ready = output<void>({ alias: 'readyPub' });",
+        "output",
+    ));
+    assert!(out.contains("\"readyPub\""), "alias from options not honored. Got:\n{out}");
+}
+
+#[test]
+fn output_from_observable_options_live_in_args_1() {
+    // outputFromObservable(source, options?) — options is args[1], not args[0].
+    // Regression: an earlier OXC AOT bug pulled options from args[0] and lost the alias.
+    let out = compile_jit(&format!(
+        "import {{ Component, outputFromObservable }} from '@angular/core';\n\
+         import {{ of }} from 'rxjs';\n\
+         @Component({{ selector: 'c', template: '', standalone: true }})\n\
+         export class C {{\n  ready = outputFromObservable(of(1), {{ alias: 'readyPub' }});\n}}\n",
+    ));
+    assert!(out.contains("\"readyPub\""), "alias from args[1] not honored. Got:\n{out}");
+}
+
+#[test]
+fn model_synthesizes_input_and_output_pair() {
+    let out = compile_jit(&component("  readonly value = model(0);", "model"));
+    // Both decorators on the same field.
+    assert!(out.contains("type: Input"), "@Input half of model() missing. Got:\n{out}");
+    assert!(out.contains("type: Output"), "@Output half of model() missing. Got:\n{out}");
+    // Output alias is `<input>Change` (matches ngc behavior).
+    assert!(out.contains("\"valueChange\""), "model's output alias `<name>Change` missing. Got:\n{out}");
+}
+
+#[test]
+fn model_required_propagates_required_to_input() {
+    let out = compile_jit(&component("  readonly value = model.required<string>();", "model"));
+    assert!(out.contains("required: true"), "model.required() should set Input.required. Got:\n{out}");
+}
+
+#[test]
+fn view_child_emits_synthesized_view_child_with_is_signal() {
+    let out = compile_jit(&component(
+        "  readonly el = viewChild<ElementRef>('ref');",
+        "viewChild, ElementRef",
+    ));
+    assert!(out.contains("type: ViewChild"), "synthesized @ViewChild missing. Got:\n{out}");
+    assert!(out.contains("isSignal: true"), "isSignal flag missing on query. Got:\n{out}");
+    // OXC's TS stripper normalizes single-quoted string literals to double-quoted, so
+    // assert against the post-strip form. The locator text just needs to survive.
+    assert!(out.contains("\"ref\""), "locator (positional arg 0) lost. Got:\n{out}");
+}
+
+#[test]
+fn view_child_with_options_spreads_existing_options() {
+    let out = compile_jit(&component(
+        "  readonly el = viewChild<ElementRef>('ref', { read: ElementRef });",
+        "viewChild, ElementRef",
+    ));
+    assert!(out.contains("...{ read: ElementRef }"), "options spread missing. Got:\n{out}");
+    assert!(out.contains("isSignal: true"), "isSignal still folded in. Got:\n{out}");
+}
+
+#[test]
+fn view_children_emits_view_children_decorator() {
+    let out = compile_jit(&component(
+        "  readonly els = viewChildren<ElementRef>('ref');",
+        "viewChildren, ElementRef",
+    ));
+    assert!(out.contains("type: ViewChildren"), "Got:\n{out}");
+}
+
+#[test]
+fn content_child_required_emits_content_child() {
+    let out = compile_jit(&component(
+        "  readonly el = contentChild.required<ElementRef>('ref');",
+        "contentChild, ElementRef",
+    ));
+    // .required() variant maps to the same decorator name (ContentChild), with isSignal.
+    assert!(out.contains("type: ContentChild"), "Got:\n{out}");
+    assert!(out.contains("isSignal: true"), "Got:\n{out}");
+}
+
+#[test]
+fn explicit_view_child_decorator_blocks_query_synthesis() {
+    // Mirrors the AOT regression test in component.spec.ts:272 — explicit @ViewChild
+    // wins over the signal-derived query so the field isn't registered twice.
+    let out = compile_jit(&component(
+        "  @ViewChild('r') r = viewChild<ElementRef>('r');",
+        "viewChild, ViewChild, ElementRef",
+    ));
+    assert!(out.contains("type: ViewChild"), "explicit @ViewChild lost. Got:\n{out}");
+    assert!(
+        !out.contains("isSignal"),
+        "synthesis must skip when explicit query decorator coexists. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #312.

## Summary

- Detect property initializers calling `input()`, `output()`, `outputFromObservable()`, `model()`, `viewChild()`/`viewChildren()`, `contentChild()`/`contentChildren()` (and `.required()` variants) on classes carrying `@Component`/`@Directive`
- Synthesize the matching `@Input`/`@Output`/`@ViewChild`/etc. entries into `static propDecorators` so the runtime JIT facade can discover inputs, outputs, and queries
- Mirrors `packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/`
- Skip synthesis when an explicit matching decorator already coexists on the field (decorator wins, matches upstream `signal*Transform` early-return)

## Behavior changes

For a JIT-compiled class:

```ts
@Component({ selector: 'c', template: '' })
export class C {
  readonly value = input(0);
  readonly clicked = output<void>();
  readonly el = viewChild<ElementRef>('ref');
}
```

Before:
```js
static propDecorators = {};
// runtime sees no inputs/outputs/queries — setInput fails (NG0315)
```

After:
```js
static propDecorators = {
  value: [{ type: Input, args: [{ isSignal: true, alias: "value", required: false, transform: undefined }] }],
  clicked: [{ type: Output, args: ["clicked"] }],
  el: [{ type: ViewChild, args: ["ref", { isSignal: true }] }],
};
```

## Notes on the upstream port

- Three call shapes recognized: bare identifier (`input(...)`), `.required` member (`input.required(...)`), namespaced (`core.input(...)`)
- `as`/`satisfies`/parenthesized wrappers unwrapped, matching ngc's `tryParseInitializerApi`
- Argument positions match the runtime APIs:
  - `input(default, options?)` / `model(default, options?)` — options in `args[1]`
  - `input.required(options?)` / `model.required(options?)` — options in `args[0]`
  - `output(options?)` — options in `args[0]`
  - `outputFromObservable(observable, options?)` — options in `args[1]`
  - Queries — locator in `args[0]`, options in `args[1]` (spread with `isSignal: true` folded)
- `model()` emits two decorators per field: `@Input({isSignal, alias, required, transform: undefined})` and `@Output("<alias>Change")`

## Test plan

- [x] 14 new focused tests in `crates/oxc_angular_compiler/tests/jit_signal_initializer_test.rs` cover each API, alias-from-options, `.required` variants, explicit-decorator-wins precedence, and the `outputFromObservable` args[1] regression
- [x] Full `cargo test -p oxc_angular_compiler` passes — no regressions across the existing ~1200 tests
- [ ] Reviewer to spot-check the synthesized text shape against ngc compliance fixtures if desired (e.g. `packages/compiler-cli/test/compliance/test_cases/signal_inputs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)