### PR TITLE
feat(transform): support @Service decorator in JIT downlevel transform (#311)

### DIFF
--- a/crates/oxc_angular_compiler/src/component/metadata.rs
+++ b/crates/oxc_angular_compiler/src/component/metadata.rs
@@ -63,6 +63,15 @@ impl AngularVersion {
         self.major >= 20
     }
 
+    /// Check if this version supports the `@Service` decorator (v22.0.0+).
+    ///
+    /// Angular v22 introduced the `@Service` decorator as a lighter alternative to
+    /// `@Injectable`. The runtime gains `compileService`/`ɵɵdefineService` in the same
+    /// release, so earlier versions cannot consume downleveled `@Service` metadata.
+    pub fn supports_service_decorator(&self) -> bool {
+        self.major >= 22
+    }
+
     /// Parse a version string like "19.0.0" or "19.0.0-rc.1".
     ///
     /// Returns `None` if the version string is invalid.

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -865,8 +865,20 @@ struct JitNonAngularMemberDecorator {
 }
 
 /// Find any Angular decorator on a class and return its kind and the decorator reference.
+///
+/// For the `Service` identifier specifically, the import map is consulted so a
+/// bare `@Service()` from a non-Angular library doesn't shadow a real Angular
+/// decorator that follows it on the same class. `Service` is common enough as a
+/// library export name (DI containers, web frameworks) that name-only matching
+/// would cause the JIT pipeline to either misclassify the class or, on
+/// pre-v22 targets, emit a misleading diagnostic and skip the sibling
+/// `@Component`/`@Injectable`/etc. Other Angular decorator names are unique
+/// enough in practice that the same check isn't applied to them — and doing so
+/// would regress namespace-style usage like `@core.Component()` where the
+/// identifier isn't directly in the import map.
 fn find_angular_decorator<'a>(
     class: &'a oxc_ast::ast::Class<'a>,
+    import_map: &ImportMap<'a>,
 ) -> Option<(AngularDecoratorKind, &'a oxc_ast::ast::Decorator<'a>)> {
     for decorator in &class.decorators {
         if let Expression::CallExpression(call) = &decorator.expression {
@@ -875,14 +887,30 @@ fn find_angular_decorator<'a>(
                 Expression::StaticMemberExpression(member) => Some(member.property.name.as_str()),
                 _ => None,
             };
-            match name {
-                Some("Component") => return Some((AngularDecoratorKind::Component, decorator)),
-                Some("Directive") => return Some((AngularDecoratorKind::Directive, decorator)),
-                Some("Pipe") => return Some((AngularDecoratorKind::Pipe, decorator)),
-                Some("Injectable") => return Some((AngularDecoratorKind::Injectable, decorator)),
-                Some("Service") => return Some((AngularDecoratorKind::Service, decorator)),
-                Some("NgModule") => return Some((AngularDecoratorKind::NgModule, decorator)),
-                _ => {}
+            let kind = match name {
+                Some("Component") => Some(AngularDecoratorKind::Component),
+                Some("Directive") => Some(AngularDecoratorKind::Directive),
+                Some("Pipe") => Some(AngularDecoratorKind::Pipe),
+                Some("Injectable") => Some(AngularDecoratorKind::Injectable),
+                Some("Service") => Some(AngularDecoratorKind::Service),
+                Some("NgModule") => Some(AngularDecoratorKind::NgModule),
+                _ => None,
+            };
+
+            if matches!(kind, Some(AngularDecoratorKind::Service)) {
+                if let Expression::Identifier(id) = &call.callee {
+                    let info = import_map.get(&Ident::from(id.name.as_str()));
+                    let from_angular_core = info
+                        .map(|info| info.source_module.as_str() == "@angular/core")
+                        .unwrap_or(false);
+                    if !from_angular_core {
+                        continue;
+                    }
+                }
+            }
+
+            if let Some(k) = kind {
+                return Some((k, decorator));
             }
         }
     }
@@ -1546,6 +1574,12 @@ fn transform_angular_file_jit(
     // / `styleUrls`, matching the AOT metadata extraction path.
     let string_consts = collect_string_consts(allocator, &parser_ret.program);
 
+    // Build an import map so `find_angular_decorator` can verify that a bare
+    // `@Service()` is actually Angular's, not a same-named decorator from
+    // another library.
+    let import_map =
+        build_import_map(allocator, &parser_ret.program.body, options.resolved_imports.as_ref());
+
     // 3. Walk AST to find Angular-decorated classes
     let mut jit_classes: std::vec::Vec<JitClassInfo> = std::vec::Vec::new();
     let mut resource_counter: u32 = 0;
@@ -1576,7 +1610,8 @@ fn transform_angular_file_jit(
             continue;
         };
 
-        let Some((decorator_kind, angular_decorator)) = find_angular_decorator(class) else {
+        let Some((decorator_kind, angular_decorator)) = find_angular_decorator(class, &import_map)
+        else {
             continue;
         };
 

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -795,6 +795,7 @@ enum AngularDecoratorKind {
     Directive,
     Pipe,
     Injectable,
+    Service,
     NgModule,
 }
 
@@ -879,6 +880,7 @@ fn find_angular_decorator<'a>(
                 Some("Directive") => return Some((AngularDecoratorKind::Directive, decorator)),
                 Some("Pipe") => return Some((AngularDecoratorKind::Pipe, decorator)),
                 Some("Injectable") => return Some((AngularDecoratorKind::Injectable, decorator)),
+                Some("Service") => return Some((AngularDecoratorKind::Service, decorator)),
                 Some("NgModule") => return Some((AngularDecoratorKind::NgModule, decorator)),
                 _ => {}
             }
@@ -995,6 +997,7 @@ const ANGULAR_DECORATOR_NAMES: &[&str] = &[
     "Directive",
     "Pipe",
     "Injectable",
+    "Service",
     "NgModule",
 ];
 
@@ -1576,6 +1579,21 @@ fn transform_angular_file_jit(
         let Some((decorator_kind, angular_decorator)) = find_angular_decorator(class) else {
             continue;
         };
+
+        // Version gating: the `@Service` decorator requires Angular v22+, where the
+        // runtime JIT facade gained `compileService`/`ɵɵdefineService`. When targeting an
+        // older version, surface the gap and leave the decorator unchanged (pass-through)
+        // so the JIT downlevel pipeline doesn't emit metadata the runtime can't consume.
+        // When the version is unknown, assume support (matches the `map_or(true, …)` pattern).
+        if matches!(decorator_kind, AngularDecoratorKind::Service)
+            && !options.angular_version.map_or(true, |v| v.supports_service_decorator())
+        {
+            result.diagnostics.push(OxcDiagnostic::error(format!(
+                "The @Service decorator on '{}' requires Angular v22 or later.",
+                class_name
+            )));
+            continue;
+        }
 
         // Collect ALL class-level decorator spans and texts (in source order)
         let mut all_class_decorator_spans: std::vec::Vec<Span> = std::vec::Vec::new();

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -6961,6 +6961,57 @@ export class CounterService {}
 }
 
 #[test]
+fn test_jit_non_angular_service_decorator_does_not_shadow_injectable() {
+    // A `@Service()` decorator from a non-Angular library must not cause the JIT
+    // pipeline to misclassify the class as v22 `@Service`, nor (on pre-v22
+    // targets) swallow a sibling `@Injectable` via the version-gate's early
+    // `continue`. Name matching alone is insufficient — `Service` is a common
+    // export name in DI containers and web frameworks.
+    let allocator = Allocator::default();
+    let source = r"
+import { Injectable } from '@angular/core';
+import { Service } from 'some-other-lib';
+
+@Service()
+@Injectable()
+export class CounterService {
+    constructor(private http: HttpClient) {}
+}
+";
+
+    let options = ComponentTransformOptions {
+        jit: true,
+        angular_version: Some(AngularVersion::new(21, 0, 0)),
+        ..Default::default()
+    };
+    let result =
+        transform_angular_file(&allocator, "counter.service.ts", source, Some(&options), None);
+
+    // No "@Service requires v22" diagnostic should fire — this isn't Angular's
+    // Service.
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|d| d.to_string().contains("@Service") && d.to_string().contains("v22")),
+        "Non-Angular @Service should not trigger the v22 diagnostic. Got: {:?}",
+        result.diagnostics
+    );
+
+    // The real @Injectable must still be lowered.
+    assert!(
+        result.code.contains("__decorate("),
+        "JIT output should still lower @Injectable via __decorate. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("ctorParameters") && result.code.contains("HttpClient"),
+        "JIT output should emit ctorParameters for the lowered @Injectable. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_jit_full_component_example() {
     // Full example matching the issue #97 scenario
     let allocator = Allocator::default();

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -6865,6 +6865,102 @@ export class HighlightDirective {
 }
 
 #[test]
+fn test_jit_service_decorator() {
+    // @Service (Angular v22+) should be JIT-downleveled exactly like @Injectable:
+    // decorator removed, static decorators/ctorParameters emitted, and __decorate applied.
+    let allocator = Allocator::default();
+    let source = r"
+import { Service } from '@angular/core';
+
+@Service()
+export class CounterService {
+    constructor(private http: HttpClient) {}
+}
+";
+
+    let options = ComponentTransformOptions { jit: true, ..Default::default() };
+    let result =
+        transform_angular_file(&allocator, "counter.service.ts", source, Some(&options), None);
+    assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
+
+    // The @Service decorator should be removed and lowered through __decorate.
+    assert!(
+        !result.code.contains("@Service"),
+        "JIT output should NOT contain the @Service decorator. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("__decorate("),
+        "JIT service output should use __decorate. Got:\n{}",
+        result.code
+    );
+
+    // ctorParameters reflecting the constructor dependency should be emitted.
+    assert!(
+        result.code.contains("ctorParameters") && result.code.contains("HttpClient"),
+        "JIT service output should emit ctorParameters with HttpClient. Got:\n{}",
+        result.code
+    );
+
+    // JIT must NOT emit AOT definitions; the runtime's compileService handles that.
+    assert!(
+        !result.code.contains("ɵsvc") && !result.code.contains("ɵfac"),
+        "JIT service output should NOT contain AOT definitions. Got:\n{}",
+        result.code
+    );
+
+    insta::assert_snapshot!("jit_service_decorator", result.code);
+}
+
+#[test]
+fn test_jit_service_decorator_version_gated() {
+    // Targeting Angular < 22 must not downlevel @Service (the runtime lacks
+    // compileService). The decorator is left in source and a diagnostic is surfaced.
+    let allocator = Allocator::default();
+    let source = r"
+import { Service } from '@angular/core';
+
+@Service()
+export class CounterService {}
+";
+
+    let options = ComponentTransformOptions {
+        jit: true,
+        angular_version: Some(AngularVersion::new(21, 0, 0)),
+        ..Default::default()
+    };
+    let result =
+        transform_angular_file(&allocator, "counter.service.ts", source, Some(&options), None);
+
+    // A diagnostic should be surfaced for the unsupported decorator.
+    assert!(
+        result.has_errors(),
+        "Targeting v21 with @Service should produce a diagnostic. Got none.\n{}",
+        result.code
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.to_string().contains("@Service") && d.to_string().contains("v22")),
+        "Diagnostic should mention @Service and v22. Got: {:?}",
+        result.diagnostics
+    );
+
+    // The decorator should remain in the source (pass-through, not downleveled).
+    assert!(
+        result.code.contains("@Service"),
+        "JIT output for v21 should leave the @Service decorator unchanged. Got:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("__decorate("),
+        "JIT output for v21 should NOT downlevel @Service via __decorate. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_jit_full_component_example() {
     // Full example matching the issue #97 scenario
     let allocator = Allocator::default();

--- a/crates/oxc_angular_compiler/tests/snapshots/integration_test__jit_service_decorator.snap
+++ b/crates/oxc_angular_compiler/tests/snapshots/integration_test__jit_service_decorator.snap
@@ -1,0 +1,14 @@
+---
+source: crates/oxc_angular_compiler/tests/integration_test.rs
+expression: result.code
+---
+import { Service } from "@angular/core";
+import { __decorate } from "tslib";
+let CounterService = class CounterService {
+	constructor(http) {
+		this.http = http;
+	}
+	static ctorParameters = () => [{ type: HttpClient }];
+};
+CounterService = __decorate([Service()], CounterService);
+export { CounterService };


### PR DESCRIPTION
Closes #311

Recognize Angular v22's @Service decorator in the JIT downlevel pipeline so
the runtime JIT facade (compileService) can rediscover it. A @Service class is
now restructured the same way as @Injectable: decorator removed, static
decorators/ctorParameters emitted, and lowered via __decorate(...).

- Add `Service` variant to `AngularDecoratorKind` and match it in
  `find_angular_decorator`; include `"Service"` in `ANGULAR_DECORATOR_NAMES`.
- Add `AngularVersion::supports_service_decorator()` (v22+) helper.
- Version-gate: when targeting Angular < 22, emit a diagnostic and leave the
  @Service decorator unchanged (pass-through), since the runtime lacks
  compileService. Unknown version defaults to "supports".
- Tests: @Service downlevels like @Injectable (snapshot); targeting v21
  surfaces a diagnostic and leaves the decorator in source.

https://claude.ai/code/session_01U6t6qXHNPsEUk5ZFEcB8NQ