### PR TITLE
fix(directive): chain query instructions on Angular ≥ 21.0.4, align _c<N> ordering

### DIFF
--- a/crates/oxc_angular_compiler/src/component/metadata.rs
+++ b/crates/oxc_angular_compiler/src/component/metadata.rs
@@ -72,6 +72,30 @@ impl AngularVersion {
         self.major >= 22
     }
 
+    /// Check if this version's runtime supports chained query instructions
+    /// (`ɵɵviewQuery(p1)(p2)`, `ɵɵcontentQuerySignal(...)(...)`).
+    ///
+    /// Until `angular/angular@ae1c0dc4` ("perf(compiler): chain query creation
+    /// instructions", landed in v21.1.0 and cherry-picked into v21.0.4 as
+    /// `f901cc9e`), `ɵɵviewQuery` / `ɵɵcontentQuery` / `ɵɵviewQuerySignal` /
+    /// `ɵɵcontentQuerySignal` all returned `void`. Chained emit on those
+    /// versions throws at runtime: `TypeError: ɵɵviewQuery(...) is not a
+    /// function`. From v21.0.4+ they return `typeof <fn>` and chain safely.
+    pub fn supports_chained_queries(&self) -> bool {
+        // v22+ unconditionally, v21.1.0+ on the v21 line, v21.0.4+ on the
+        // v21.0 cherry-pick. Anything below v21 is `void`-return territory.
+        if self.major >= 22 {
+            return true;
+        }
+        if self.major == 21 {
+            if self.minor >= 1 {
+                return true;
+            }
+            return self.minor == 0 && self.patch >= 4;
+        }
+        false
+    }
+
     /// Parse a version string like "19.0.0" or "19.0.0-rc.1".
     ///
     /// Returns `None` if the version string is invalid.

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -2685,6 +2685,7 @@ pub fn transform_angular_file(
                         allocator,
                         &directive_metadata,
                         shared_pool_index,
+                        options.angular_version,
                     );
 
                     // Update shared_pool_index for the next compilation
@@ -3430,6 +3431,7 @@ fn compile_component_full<'a>(
             view_queries.as_slice(),
             fn_name,
             Some(&mut job.pool),
+            options.angular_version,
         ))
     } else {
         None
@@ -3444,6 +3446,7 @@ fn compile_component_full<'a>(
             content_queries.as_slice(),
             fn_name,
             Some(&mut job.pool),
+            options.angular_version,
         ))
     } else {
         None

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -3421,14 +3421,22 @@ fn compile_component_full<'a>(
     // See: packages/compiler/src/render3/view/compiler.ts lines 192-212
     let attrs_ref = pool_selector_attrs(allocator, &mut job, metadata);
 
-    // BEFORE template compilation: Pool view query predicates.
-    // TypeScript Angular pools query predicates BEFORE template compilation and pure functions.
-    // This ensures correct constant ordering: attrs -> query predicates -> pure functions.
-    let view_query_fn = if !view_queries.is_empty() {
+    // BEFORE template compilation: Pool query predicates so they
+    // appear in the constant table as `attrs -> query predicates ->
+    // pure functions`.
+    //
+    // Order matters: upstream ngtsc pools **content queries first, then
+    // view queries** (compiler/src/render3/view/compiler.ts emits
+    // `contentQueries:` before `viewQuery:` in the metadata object, and
+    // pools predicates in the same order). Reversing this swaps the
+    // `_c<N>` indices visible in the emitted query calls — the runtime
+    // still works either way but the emit diverges from upstream and
+    // breaks goldens / source-anchored tooling.
+    let content_queries_fn = if !content_queries.is_empty() {
         let fn_name = Some(metadata.class_name.as_str());
-        Some(create_view_queries_function(
+        Some(create_content_queries_function(
             allocator,
-            view_queries.as_slice(),
+            content_queries.as_slice(),
             fn_name,
             Some(&mut job.pool),
             options.angular_version,
@@ -3437,13 +3445,11 @@ fn compile_component_full<'a>(
         None
     };
 
-    // BEFORE template compilation: Pool content query predicates.
-    // Similar to view queries, content query predicates are pooled before template compilation.
-    let content_queries_fn = if !content_queries.is_empty() {
+    let view_query_fn = if !view_queries.is_empty() {
         let fn_name = Some(metadata.class_name.as_str());
-        Some(create_content_queries_function(
+        Some(create_view_queries_function(
             allocator,
-            content_queries.as_slice(),
+            view_queries.as_slice(),
             fn_name,
             Some(&mut job.pool),
             options.angular_version,

--- a/crates/oxc_angular_compiler/src/directive/compiler.rs
+++ b/crates/oxc_angular_compiler/src/directive/compiler.rs
@@ -61,8 +61,9 @@ pub fn compile_directive<'a>(
     allocator: &'a Allocator,
     metadata: &R3DirectiveMetadata<'a>,
     pool_starting_index: u32,
+    angular_version: Option<crate::AngularVersion>,
 ) -> DirectiveCompileResult<'a> {
-    compile_directive_from_metadata(allocator, metadata, pool_starting_index)
+    compile_directive_from_metadata(allocator, metadata, pool_starting_index, angular_version)
 }
 
 /// Internal implementation of directive compilation.
@@ -70,10 +71,11 @@ pub fn compile_directive_from_metadata<'a>(
     allocator: &'a Allocator,
     metadata: &R3DirectiveMetadata<'a>,
     pool_starting_index: u32,
+    angular_version: Option<crate::AngularVersion>,
 ) -> DirectiveCompileResult<'a> {
     // Build the base directive fields, passing pool_starting_index for host bindings
     let (definition_map, next_pool_index, host_declarations) =
-        build_base_directive_fields(allocator, metadata, pool_starting_index);
+        build_base_directive_fields(allocator, metadata, pool_starting_index, angular_version);
 
     // Add features
     let mut definition_map = definition_map;
@@ -102,6 +104,7 @@ fn build_base_directive_fields<'a>(
     allocator: &'a Allocator,
     metadata: &R3DirectiveMetadata<'a>,
     pool_starting_index: u32,
+    angular_version: Option<crate::AngularVersion>,
 ) -> (Vec<'a, LiteralMapEntry<'a>>, u32, oxc_allocator::Vec<'a, OutputStatement<'a>>) {
     let mut entries = Vec::new_in(allocator);
     let mut next_pool_index = pool_starting_index;
@@ -130,6 +133,7 @@ fn build_base_directive_fields<'a>(
             &metadata.queries,
             Some(metadata.name.as_str()),
             None,
+            angular_version,
         );
         entries.push(LiteralMapEntry::new(
             Ident::from("contentQueries"),
@@ -147,6 +151,7 @@ fn build_base_directive_fields<'a>(
             &metadata.view_queries,
             Some(metadata.name.as_str()),
             None,
+            angular_version,
         );
         entries.push(LiteralMapEntry::new(Ident::from("viewQuery"), view_queries_fn, false));
     }
@@ -1003,7 +1008,7 @@ mod tests {
             host_directives: Vec::new_in(&allocator),
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
@@ -1047,7 +1052,7 @@ mod tests {
             host_directives: Vec::new_in(&allocator),
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
 
@@ -1300,7 +1305,7 @@ mod tests {
             host_directives: Vec::new_in(&allocator),
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
 
@@ -1342,7 +1347,7 @@ mod tests {
             host_directives: Vec::new_in(&allocator),
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
 
@@ -1382,7 +1387,7 @@ mod tests {
             host_directives: Vec::new_in(&allocator),
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
 
@@ -1437,7 +1442,7 @@ mod tests {
             host_directives: Vec::new_in(&allocator),
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
 
@@ -1498,7 +1503,7 @@ mod tests {
             host_directives,
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
         let normalized = output.replace([' ', '\n', '\t'], "");
@@ -1563,7 +1568,7 @@ mod tests {
             host_directives,
         };
 
-        let result = compile_directive(&allocator, &metadata, 0);
+        let result = compile_directive(&allocator, &metadata, 0, None);
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result.expression);
         let normalized = output.replace([' ', '\n', '\t'], "");

--- a/crates/oxc_angular_compiler/src/directive/definition.rs
+++ b/crates/oxc_angular_compiler/src/directive/definition.rs
@@ -72,6 +72,7 @@ pub fn generate_directive_definitions<'a>(
     allocator: &'a Allocator,
     metadata: &R3DirectiveMetadata<'a>,
     pool_starting_index: u32,
+    angular_version: Option<crate::AngularVersion>,
 ) -> DirectiveDefinitions<'a> {
     // IMPORTANT: Generate ɵfac BEFORE ɵdir to match Angular's namespace index assignment order.
     // Angular processes results in order [fac, def, ...] during the transform phase
@@ -80,7 +81,7 @@ pub fn generate_directive_definitions<'a>(
     // This ensures namespace indices (i0, i1, i2, ...) are assigned in the same order.
     let fac_definition = generate_fac_definition(allocator, metadata);
     let (dir_definition, next_pool_index) =
-        generate_dir_definition(allocator, metadata, pool_starting_index);
+        generate_dir_definition(allocator, metadata, pool_starting_index, angular_version);
 
     DirectiveDefinitions { dir_definition, fac_definition, next_pool_index }
 }
@@ -104,8 +105,9 @@ fn generate_dir_definition<'a>(
     allocator: &'a Allocator,
     metadata: &R3DirectiveMetadata<'a>,
     pool_starting_index: u32,
+    angular_version: Option<crate::AngularVersion>,
 ) -> (OutputExpression<'a>, u32) {
-    let result = compile_directive(allocator, metadata, pool_starting_index);
+    let result = compile_directive(allocator, metadata, pool_starting_index, angular_version);
     (result.expression, result.next_pool_index)
 }
 
@@ -228,7 +230,7 @@ mod tests {
         let allocator = Allocator::default();
         let metadata = create_test_metadata(&allocator);
 
-        let definitions = generate_directive_definitions(&allocator, &metadata, 0);
+        let definitions = generate_directive_definitions(&allocator, &metadata, 0, None);
 
         let emitter = JsEmitter::new();
 
@@ -398,7 +400,7 @@ mod tests {
         let allocator = Allocator::default();
         let metadata = create_test_metadata(&allocator);
 
-        let (dir, _next_pool_index) = generate_dir_definition(&allocator, &metadata, 0);
+        let (dir, _next_pool_index) = generate_dir_definition(&allocator, &metadata, 0, None);
 
         let emitter = JsEmitter::new();
         let js = emitter.emit_expression(&dir);
@@ -448,7 +450,7 @@ mod tests {
         };
 
         // Compile first directive
-        let definitions1 = generate_directive_definitions(&allocator, &metadata1, 0);
+        let definitions1 = generate_directive_definitions(&allocator, &metadata1, 0, None);
         let next_index = definitions1.next_pool_index;
 
         // The next_pool_index should be 0 when no constants are pooled
@@ -485,7 +487,7 @@ mod tests {
         };
 
         // Compile second directive starting from where first left off
-        let definitions2 = generate_directive_definitions(&allocator, &metadata2, next_index);
+        let definitions2 = generate_directive_definitions(&allocator, &metadata2, next_index, None);
 
         // Verify both directives compiled successfully
         let emitter = JsEmitter::new();

--- a/crates/oxc_angular_compiler/src/directive/query.rs
+++ b/crates/oxc_angular_compiler/src/directive/query.rs
@@ -446,6 +446,7 @@ pub fn create_view_queries_function<'a>(
     view_queries: &[R3QueryMetadata<'a>],
     name: Option<&str>,
     pool: Option<&mut ConstantPool<'a>>,
+    angular_version: Option<crate::AngularVersion>,
 ) -> OutputExpression<'a> {
     // Pre-pool all string selector predicates BEFORE building the function.
     // This ensures query predicates are pooled to top-level constants in the correct order
@@ -460,6 +461,28 @@ pub fn create_view_queries_function<'a>(
     let mut update_statements: Vec<'a, MaybeAdvanceStatement<'a>> = Vec::new_in(allocator);
     let mut temp_allocator = TempAllocator::new();
 
+    // Chained emit (`ɵɵviewQuery(p1)(p2)`) requires Angular 21.0.4+ /
+    // 21.1.0+ — before that the runtime functions returned `void` and a
+    // chained call would throw `TypeError: not a function`. Consumers
+    // targeting v19/v20/v21.0.0–3 must opt out by passing an explicit
+    // `angular_version`; an unset version falls in line with the rest
+    // of this crate's "assume latest" convention (see e.g.
+    // `supports_implicit_standalone`'s `map_or(true, …)` and the
+    // `angular_version: None // assume latest` comment in `transform.rs`).
+    let chain_emit = angular_version.map_or(true, |v| v.supports_chained_queries());
+    let mut current_chain: Option<OutputExpression<'a>> = None;
+    let mut current_chain_is_signal: bool = false;
+
+    fn flush_chain<'a>(
+        allocator: &'a Allocator,
+        chain: &mut Option<OutputExpression<'a>>,
+        create_statements: &mut Vec<'a, OutputStatement<'a>>,
+    ) {
+        if let Some(expr) = chain.take() {
+            create_statements.push(expr_stmt(allocator, expr));
+        }
+    }
+
     for (idx, query) in view_queries.iter().enumerate() {
         // Creation: ɵɵviewQuery(predicate, flags, read) or ɵɵviewQuerySignal(ctx.prop, predicate, flags, read)
         // Use pre-pooled predicate instead of calling get_query_create_parameters
@@ -469,15 +492,28 @@ pub fn create_view_queries_function<'a>(
             pooled_predicates[idx].clone_in(allocator),
         );
 
-        // Emit each query as a separate statement.
-        // Angular 20's ɵɵviewQuery returns void, so chaining is not supported.
-        if query.is_signal {
-            let call =
-                call_fn(allocator, import_expr(allocator, Identifiers::VIEW_QUERY_SIGNAL), params);
+        let identifier =
+            if query.is_signal { Identifiers::VIEW_QUERY_SIGNAL } else { Identifiers::VIEW_QUERY };
+
+        if !chain_emit {
+            // Pre-v21.0.4: one statement per query, no chaining.
+            let call = call_fn(allocator, import_expr(allocator, identifier), params);
             create_statements.push(expr_stmt(allocator, call));
         } else {
-            let call = call_fn(allocator, import_expr(allocator, Identifiers::VIEW_QUERY), params);
-            create_statements.push(expr_stmt(allocator, call));
+            // Flush the pending chain if this query's signal-ness differs
+            // (different runtime symbol — can't be chained off the previous call).
+            if current_chain.is_some() && current_chain_is_signal != query.is_signal {
+                flush_chain(allocator, &mut current_chain, &mut create_statements);
+            }
+
+            let callee = match current_chain.take() {
+                Some(prev) => prev,
+                None => {
+                    current_chain_is_signal = query.is_signal;
+                    import_expr(allocator, identifier)
+                }
+            };
+            current_chain = Some(call_fn(allocator, callee, params));
         }
 
         // Update phase
@@ -555,6 +591,9 @@ pub fn create_view_queries_function<'a>(
         }
     }
 
+    // Flush the trailing chain (if any) as the final create statement.
+    flush_chain(allocator, &mut current_chain, &mut create_statements);
+
     // Build update statements with temp variable declarations
     let mut final_update_statements = Vec::new_in(allocator);
 
@@ -630,6 +669,7 @@ pub fn create_content_queries_function<'a>(
     queries: &[R3QueryMetadata<'a>],
     name: Option<&str>,
     pool: Option<&mut ConstantPool<'a>>,
+    angular_version: Option<crate::AngularVersion>,
 ) -> OutputExpression<'a> {
     // Pre-pool all string selector predicates BEFORE building the function.
     // This ensures query predicates are pooled to top-level constants in the correct order
@@ -644,6 +684,23 @@ pub fn create_content_queries_function<'a>(
     let mut update_statements: Vec<'a, MaybeAdvanceStatement<'a>> = Vec::new_in(allocator);
     let mut temp_allocator = TempAllocator::new();
 
+    // See note in `create_view_queries_function` — chained content-query
+    // emit also requires v21.0.4+ runtime support, with `None` meaning
+    // "assume latest" per the rest of this crate's convention.
+    let chain_emit = angular_version.map_or(true, |v| v.supports_chained_queries());
+    let mut current_chain: Option<OutputExpression<'a>> = None;
+    let mut current_chain_is_signal: bool = false;
+
+    fn flush_chain<'a>(
+        allocator: &'a Allocator,
+        chain: &mut Option<OutputExpression<'a>>,
+        create_statements: &mut Vec<'a, OutputStatement<'a>>,
+    ) {
+        if let Some(expr) = chain.take() {
+            create_statements.push(expr_stmt(allocator, expr));
+        }
+    }
+
     for (idx, query) in queries.iter().enumerate() {
         // Prepend dirIndex parameter for content queries
         let mut prepend = Vec::new_in(allocator);
@@ -656,19 +713,27 @@ pub fn create_content_queries_function<'a>(
             prepend,
         );
 
-        // Emit each query as a separate statement.
-        // Angular 20's ɵɵcontentQuery returns void, so chaining is not supported.
-        if query.is_signal {
-            let call = call_fn(
-                allocator,
-                import_expr(allocator, Identifiers::CONTENT_QUERY_SIGNAL),
-                params,
-            );
+        let identifier = if query.is_signal {
+            Identifiers::CONTENT_QUERY_SIGNAL
+        } else {
+            Identifiers::CONTENT_QUERY
+        };
+
+        if !chain_emit {
+            let call = call_fn(allocator, import_expr(allocator, identifier), params);
             create_statements.push(expr_stmt(allocator, call));
         } else {
-            let call =
-                call_fn(allocator, import_expr(allocator, Identifiers::CONTENT_QUERY), params);
-            create_statements.push(expr_stmt(allocator, call));
+            if current_chain.is_some() && current_chain_is_signal != query.is_signal {
+                flush_chain(allocator, &mut current_chain, &mut create_statements);
+            }
+            let callee = match current_chain.take() {
+                Some(prev) => prev,
+                None => {
+                    current_chain_is_signal = query.is_signal;
+                    import_expr(allocator, identifier)
+                }
+            };
+            current_chain = Some(call_fn(allocator, callee, params));
         }
 
         // Update phase (same as view queries)
@@ -738,6 +803,9 @@ pub fn create_content_queries_function<'a>(
                 .push(MaybeAdvanceStatement::Statement(expr_stmt(allocator, and_expr)));
         }
     }
+
+    // Flush the trailing chain (if any) as the final create statement.
+    flush_chain(allocator, &mut current_chain, &mut create_statements);
 
     // Build update statements with temp variable declarations
     let mut final_update_statements = Vec::new_in(allocator);
@@ -812,7 +880,8 @@ mod tests {
         let allocator = Allocator::default();
         let queries: &[R3QueryMetadata<'_>] = &[];
 
-        let result = create_view_queries_function(&allocator, queries, Some("TestComponent"), None);
+        let result =
+            create_view_queries_function(&allocator, queries, Some("TestComponent"), None, None);
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
@@ -828,7 +897,7 @@ mod tests {
         let queries: &[R3QueryMetadata<'_>] = &[];
 
         let result =
-            create_content_queries_function(&allocator, queries, Some("TestDirective"), None);
+            create_content_queries_function(&allocator, queries, Some("TestDirective"), None, None);
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
@@ -861,7 +930,7 @@ mod tests {
 
         let queries = [query];
         let result =
-            create_view_queries_function(&allocator, &queries, Some("TestComponent"), None);
+            create_view_queries_function(&allocator, &queries, Some("TestComponent"), None, None);
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
@@ -902,8 +971,13 @@ mod tests {
         };
 
         let queries = [query];
-        let result =
-            create_content_queries_function(&allocator, &queries, Some("TestDirective"), None);
+        let result = create_content_queries_function(
+            &allocator,
+            &queries,
+            Some("TestDirective"),
+            None,
+            None,
+        );
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
@@ -922,7 +996,11 @@ mod tests {
         );
     }
 
-    /// Test two chained signal view queries
+    /// Two consecutive signal view queries should be emitted as a single
+    /// chained call — matches upstream ngtsc emit (compiler-cli compliance
+    /// `signal_queries/query_in_component.js`). `ɵɵviewQuerySignal` returns
+    /// `typeof ɵɵviewQuerySignal` (core/src/render3/instructions/
+    /// queries_signals.ts:53), so chaining is safe.
     #[test]
     fn test_chained_signal_view_queries() {
         let allocator = Allocator::default();
@@ -957,34 +1035,46 @@ mod tests {
         };
 
         let queries = [query1, query2];
-        let result =
-            create_view_queries_function(&allocator, &queries, Some("TestComponent"), None);
+        // Force the v22 path so the chained emit is exercised. On older
+        // runtimes (`None` or anything before v21.0.4) the builder emits
+        // separate statements instead — see `supports_chained_queries`.
+        let result = create_view_queries_function(
+            &allocator,
+            &queries,
+            Some("TestComponent"),
+            None,
+            Some(crate::AngularVersion::new(22, 0, 0)),
+        );
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
 
-        println!("Chained signal queries output:\n{}", output);
-
-        // Each signal query should be emitted as a separate statement.
-        // Angular 20's ɵɵviewQuerySignal returns void, so chaining is not supported.
         let normalized = output.replace(['\n', ' '], "");
         assert!(
-            normalized.contains("viewQuerySignal(ctx.query1,Component1,1);")
-                && normalized.contains("viewQuerySignal(ctx.query2,Component2,1);"),
-            "Each signal query should be a separate statement.\nGot:\n{}",
+            normalized
+                .contains("viewQuerySignal(ctx.query1,Component1,1)(ctx.query2,Component2,1);"),
+            "Consecutive signal view queries should chain.\nGot:\n{}",
+            output
+        );
+        // And there must NOT be two separate statements.
+        assert!(
+            !normalized.contains("viewQuerySignal(ctx.query1,Component1,1);"),
+            "First signal query must not be a standalone statement.\nGot:\n{}",
             output
         );
     }
 
-    /// Regression test: Multiple non-signal view queries must be separate statements.
+    /// Multiple non-signal view queries should chain — `ɵɵviewQuery`
+    /// returns `typeof ɵɵviewQuery` (core/src/render3/instructions/
+    /// queries.ts:58) and upstream emit chains them (see
+    /// compiler-cli/test/compliance/test_cases/r3_compiler_compliance/
+    /// components_and_directives/queries/*.js).
     ///
-    /// Previously, multiple view queries were chained as ɵɵviewQuery(p1)(p2), calling
-    /// the result of the first query as a function. Angular 20's ɵɵviewQuery returns void,
-    /// so chaining breaks with: TypeError: ɵɵviewQuery(...) is not a function.
-    ///
-    /// The fix: Emit each query as a separate statement.
+    /// Earlier versions of this compiler emitted separate statements based
+    /// on an incorrect "returns void" assumption — this regression test
+    /// guards the corrected behavior.
     #[test]
-    fn test_multiple_non_signal_view_queries_are_separate_statements() {
+    fn test_multiple_non_signal_view_queries_are_chained() {
         let allocator = Allocator::default();
 
         let query1 = R3QueryMetadata {
@@ -1016,41 +1106,38 @@ mod tests {
         };
 
         let queries = [query1, query2];
-        let result =
-            create_view_queries_function(&allocator, &queries, Some("TestComponent"), None);
+        let result = create_view_queries_function(
+            &allocator,
+            &queries,
+            Some("TestComponent"),
+            None,
+            Some(crate::AngularVersion::new(22, 0, 0)),
+        );
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
 
         let normalized = output.replace(['\n', ' '], "");
 
-        // Each non-signal view query should be a separate statement (ending with ;),
-        // NOT chained as ɵɵviewQuery(ChildComponent,5)(OtherComponent,5).
+        // Should produce a single chained call statement.
         assert!(
-            normalized.contains("i0.ɵɵviewQuery(ChildComponent,5);"),
-            "First view query should be a separate statement.\nGot:\n{}",
+            normalized.contains("i0.ɵɵviewQuery(ChildComponent,5)(OtherComponent,5);"),
+            "Consecutive non-signal view queries should chain.\nGot:\n{}",
             output
         );
+        // And NOT be two separate statements.
         assert!(
-            normalized.contains("i0.ɵɵviewQuery(OtherComponent,5);"),
-            "Second view query should be a separate statement.\nGot:\n{}",
-            output
-        );
-
-        // Make sure they're NOT chained (the old buggy pattern)
-        assert!(
-            !normalized.contains("viewQuery(ChildComponent,5)(OtherComponent"),
-            "View queries must NOT be chained (Angular 20 returns void).\nGot:\n{}",
+            !normalized.contains("i0.ɵɵviewQuery(ChildComponent,5);"),
+            "First view query must not be a standalone statement.\nGot:\n{}",
             output
         );
     }
 
-    /// Regression test: Multiple content queries must be separate statements.
-    ///
-    /// Same as the view query chaining bug, but for content queries.
-    /// Angular 20's ɵɵcontentQuery also returns void, so chaining breaks.
+    /// Multiple consecutive content queries should chain — same contract
+    /// as view queries (`ɵɵcontentQuery` returns `typeof ɵɵcontentQuery`,
+    /// core/src/render3/instructions/queries.ts:40).
     #[test]
-    fn test_multiple_content_queries_are_separate_statements() {
+    fn test_multiple_content_queries_are_chained() {
         let allocator = Allocator::default();
 
         let query1 = R3QueryMetadata {
@@ -1082,31 +1169,31 @@ mod tests {
         };
 
         let queries = [query1, query2];
-        let result =
-            create_content_queries_function(&allocator, &queries, Some("TestDirective"), None);
+        let result = create_content_queries_function(
+            &allocator,
+            &queries,
+            Some("TestDirective"),
+            None,
+            Some(crate::AngularVersion::new(22, 0, 0)),
+        );
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);
 
         let normalized = output.replace(['\n', ' '], "");
 
-        // Each content query should be a separate statement (ending with ;),
-        // NOT chained as ɵɵcontentQuery(dirIndex,ItemComponent,5)(dirIndex,HeaderComponent,4).
+        // Should produce a single chained call statement.
         assert!(
-            normalized.contains("i0.ɵɵcontentQuery(dirIndex,ItemComponent,5);"),
-            "First content query should be a separate statement.\nGot:\n{}",
+            normalized.contains(
+                "i0.ɵɵcontentQuery(dirIndex,ItemComponent,5)(dirIndex,HeaderComponent,4);"
+            ),
+            "Consecutive content queries should chain.\nGot:\n{}",
             output
         );
+        // And NOT be two separate statements.
         assert!(
-            normalized.contains("i0.ɵɵcontentQuery(dirIndex,HeaderComponent,4);"),
-            "Second content query should be a separate statement.\nGot:\n{}",
-            output
-        );
-
-        // Make sure they're NOT chained
-        assert!(
-            !normalized.contains("contentQuery(dirIndex,ItemComponent,5)(dirIndex,HeaderComponent"),
-            "Content queries must NOT be chained (Angular 20 returns void).\nGot:\n{}",
+            !normalized.contains("i0.ɵɵcontentQuery(dirIndex,ItemComponent,5);"),
+            "First content query must not be a standalone statement.\nGot:\n{}",
             output
         );
     }
@@ -1133,7 +1220,7 @@ mod tests {
 
         let queries = [query];
         let result =
-            create_view_queries_function(&allocator, &queries, Some("TestComponent"), None);
+            create_view_queries_function(&allocator, &queries, Some("TestComponent"), None, None);
 
         let emitter = JsEmitter::new();
         let output = emitter.emit_expression(&result);

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -5761,20 +5761,18 @@ export class ChatBotTriggerComponent {
     }
 }
 
-/// Regression: Multiple view queries must emit separate statements, not chained calls.
+/// Multiple `@ViewChild` decorators on the same component should emit
+/// as a single chained `ɵɵviewQuery(p1)(p2)(p3)` call — matches upstream
+/// ngtsc's `instructionChainAfter()` emit. `ɵɵviewQuery` returns
+/// `typeof ɵɵviewQuery` (core/src/render3/instructions/queries.ts:58),
+/// so chaining is safe.
 ///
-/// Bug: Multiple `@ViewChild`/`@ViewChildren` queries were chained as
-/// `ɵɵviewQuery(pred1)(pred2)`, treating the return value of `ɵɵviewQuery` as a callable.
-/// Angular 20's `ɵɵviewQuery` returns `void`, so chaining causes:
-/// `TypeError: i0.ɵɵviewQuery(...) is not a function`.
-///
-/// Fix: Emit each query as a separate statement:
-///   `ɵɵviewQuery(pred1); ɵɵviewQuery(pred2);`
+/// Earlier versions of this compiler emitted three separate statements
+/// based on an incorrect "returns void" reading of Angular's source.
 #[test]
-fn test_multiple_view_queries_emit_separate_statements() {
+fn test_multiple_view_queries_emit_chained_call() {
     let allocator = Allocator::default();
 
-    // Reproduce the ClickUp LoginFormComponent pattern: multiple @ViewChild decorators
     let source = r"
 import { Component, ViewChild, ElementRef } from '@angular/core';
 
@@ -5789,26 +5787,38 @@ export class LoginFormComponent {
 }
 ";
 
-    let result = transform_angular_file(&allocator, "login-form.component.ts", source, None, None);
+    // Chained query emit requires Angular ≥ 21.0.4 (queries return
+    // `typeof <fn>`, not `void`). Pin the version explicitly so this
+    // test exercises the chained path; without it the compiler falls
+    // back to the older safe separate-statement form.
+    let options = ComponentTransformOptions {
+        angular_version: Some(AngularVersion::new(22, 0, 0)),
+        ..Default::default()
+    };
+    let result =
+        transform_angular_file(&allocator, "login-form.component.ts", source, Some(&options), None);
 
     assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
 
     let code = &result.code;
 
-    // Count separate ɵɵviewQuery calls - should be 3 (one per @ViewChild)
+    // Three decorator-form view queries — one chained call expression has
+    // the root identifier `ɵɵviewQuery` appearing exactly once, with two
+    // additional `(...)` argument groups appended via chaining.
     let view_query_count = code.matches("ɵɵviewQuery(").count();
     assert_eq!(
-        view_query_count, 3,
-        "Should have exactly 3 separate ɵɵviewQuery calls. Found {view_query_count}. Output:\n{code}"
+        view_query_count, 1,
+        "Three consecutive decorator queries should chain into a single \
+         `ɵɵviewQuery(...)...` expression. Found {view_query_count} root calls. \
+         Output:\n{code}"
     );
 
-    // Must NOT have chained calls: ɵɵviewQuery(...)(...) pattern
-    // This regex-free check: after each `ɵɵviewQuery(` find the matching `)` and check
-    // the next non-whitespace char is NOT `(`
+    // The single `ɵɵviewQuery(` must be followed (after its closing `)`)
+    // by another `(` — the chain continuation.
     let query_fn = "ɵɵviewQuery(";
+    let mut chain_followups = 0;
     for (start_idx, _) in code.match_indices(query_fn) {
         let after_fn = &code[start_idx + query_fn.len()..];
-        // Find the closing paren (handle nested parens)
         let mut depth = 1;
         let mut end = 0;
         for (i, ch) in after_fn.char_indices() {
@@ -5824,22 +5834,23 @@ export class LoginFormComponent {
                 _ => {}
             }
         }
-        // Check what comes after the closing paren
-        let after_close = after_fn[end..].trim_start();
-        assert!(
-            !after_close.starts_with('('),
-            "Found chained ɵɵviewQuery call (return value used as function). \
-             Angular 20's ɵɵviewQuery returns void. Output:\n{code}"
-        );
+        if after_fn[end..].trim_start().starts_with('(') {
+            chain_followups += 1;
+        }
     }
+    assert_eq!(
+        chain_followups, 1,
+        "Chained queries should produce one continuation `(...)` after the \
+         root call. Got {chain_followups}. Output:\n{code}"
+    );
 }
 
-/// Regression: Multiple content queries must emit separate statements, not chained calls.
-///
-/// Same issue as view queries but for `@ContentChild`/`@ContentChildren`.
-/// The fix applies to both `create_view_queries_function` and `create_content_queries_function`.
+/// Multiple `@ContentChild`/`@ContentChildren` queries should emit
+/// as a single chained `ɵɵcontentQuery(...)(...)(...)` call. Same
+/// contract as `ɵɵviewQuery` — `ɵɵcontentQuery` returns
+/// `typeof ɵɵcontentQuery` (core/src/render3/instructions/queries.ts:40).
 #[test]
-fn test_multiple_content_queries_emit_separate_statements() {
+fn test_multiple_content_queries_emit_chained_call() {
     let allocator = Allocator::default();
 
     let source = r"
@@ -5856,21 +5867,28 @@ export class TabsComponent {
 }
 ";
 
-    let result = transform_angular_file(&allocator, "tabs.component.ts", source, None, None);
+    // Pin to v22 — see note on the view-query chained test above.
+    let options = ComponentTransformOptions {
+        angular_version: Some(AngularVersion::new(22, 0, 0)),
+        ..Default::default()
+    };
+    let result =
+        transform_angular_file(&allocator, "tabs.component.ts", source, Some(&options), None);
 
     assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
 
     let code = &result.code;
 
-    // Count separate ɵɵcontentQuery calls - should be 3
     let content_query_count = code.matches("ɵɵcontentQuery(").count();
     assert_eq!(
-        content_query_count, 3,
-        "Should have exactly 3 separate ɵɵcontentQuery calls. Found {content_query_count}. Output:\n{code}"
+        content_query_count, 1,
+        "Three consecutive decorator content queries should chain into a single \
+         `ɵɵcontentQuery(...)...` expression. Found {content_query_count} root calls. \
+         Output:\n{code}"
     );
 
-    // Must NOT have chained calls
     let query_fn = "ɵɵcontentQuery(";
+    let mut chain_followups = 0;
     for (start_idx, _) in code.match_indices(query_fn) {
         let after_fn = &code[start_idx + query_fn.len()..];
         let mut depth = 1;
@@ -5888,21 +5906,24 @@ export class TabsComponent {
                 _ => {}
             }
         }
-        let after_close = after_fn[end..].trim_start();
-        assert!(
-            !after_close.starts_with('('),
-            "Found chained ɵɵcontentQuery call. Angular 20's query functions return void. Output:\n{code}"
-        );
+        if after_fn[end..].trim_start().starts_with('(') {
+            chain_followups += 1;
+        }
     }
+    assert_eq!(
+        chain_followups, 1,
+        "Should produce one continuation `(...)` after the root content-query call. \
+         Got {chain_followups}. Output:\n{code}"
+    );
 }
 
-/// Regression: Mixed view queries (signal + decorator) must all be separate statements.
-///
-/// Signal-based queries (`viewChild()`, `viewChildren()`) and decorator-based queries
-/// (`@ViewChild`, `@ViewChildren`) can coexist on the same component. All of them must
-/// emit as separate statements.
+/// Mixed signal + decorator view queries: consecutive same-kind calls
+/// chain (`ɵɵviewQuerySignal(...)(...)` for the two signal queries), but
+/// the chain breaks at the boundary to the decorator-form
+/// (`ɵɵviewQuery(...)`) because the two runtime symbols aren't
+/// interchangeable.
 #[test]
-fn test_mixed_signal_and_decorator_view_queries_separate_statements() {
+fn test_mixed_signal_and_decorator_view_queries_break_chain_on_boundary() {
     let allocator = Allocator::default();
 
     let source = r"
@@ -5919,21 +5940,42 @@ export class MixedQueryComponent {
 }
 ";
 
-    let result = transform_angular_file(&allocator, "mixed-query.component.ts", source, None, None);
+    // Pin to v22 — see note on the view-query chained test above.
+    let options = ComponentTransformOptions {
+        angular_version: Some(AngularVersion::new(22, 0, 0)),
+        ..Default::default()
+    };
+    let result = transform_angular_file(
+        &allocator,
+        "mixed-query.component.ts",
+        source,
+        Some(&options),
+        None,
+    );
 
     assert!(!result.has_errors(), "Should not have errors: {:?}", result.diagnostics);
 
     let code = &result.code;
 
-    // Should have signal query calls AND decorator query calls, all separate
-    let total_query_calls = code.matches("ɵɵviewQuery").count();
-    assert!(
-        total_query_calls >= 3,
-        "Should have at least 3 view query calls (signal + decorator). Found {total_query_calls}. Output:\n{code}"
+    // Exactly one root ɵɵviewQuerySignal call (the two signal queries chain
+    // into it) and exactly one root ɵɵviewQuery call (the decorator one).
+    let signal_roots = code.matches("ɵɵviewQuerySignal(").count();
+    let decorator_roots = code.matches("ɵɵviewQuery(").count();
+    assert_eq!(
+        signal_roots, 1,
+        "Two signal view queries should chain into one root call. \
+         Found {signal_roots}. Output:\n{code}"
+    );
+    assert_eq!(
+        decorator_roots, 1,
+        "The single decorator view query should produce one root call after \
+         the signal chain breaks. Found {decorator_roots}. Output:\n{code}"
     );
 
-    // Verify no chaining for any view query variant
-    for query_fn in ["ɵɵviewQuerySignal(", "ɵɵviewQuery("] {
+    // Signal chain should have exactly one continuation `(...)` (the second
+    // signal call). The decorator call should have zero continuations.
+    fn count_chain_followups(code: &str, query_fn: &str) -> usize {
+        let mut followups = 0;
         for (start_idx, _) in code.match_indices(query_fn) {
             let after_fn = &code[start_idx + query_fn.len()..];
             let mut depth = 1;
@@ -5951,12 +5993,94 @@ export class MixedQueryComponent {
                     _ => {}
                 }
             }
-            let after_close = after_fn[end..].trim_start();
-            assert!(
-                !after_close.starts_with('('),
-                "Found chained {query_fn} call. Output:\n{code}"
-            );
+            if after_fn[end..].trim_start().starts_with('(') {
+                followups += 1;
+            }
         }
+        followups
+    }
+    assert_eq!(
+        count_chain_followups(code, "ɵɵviewQuerySignal("),
+        1,
+        "Two consecutive signal queries should chain (one continuation). \
+         Output:\n{code}"
+    );
+    assert_eq!(
+        count_chain_followups(code, "ɵɵviewQuery("),
+        0,
+        "Single decorator query should have no chain continuation. \
+         Output:\n{code}"
+    );
+}
+
+/// Compatibility guard. Two contracts at once:
+///
+/// 1. **`None` = assume latest.** Crates-wide convention: unset
+///    `angular_version` means the consumer is on latest, so the
+///    compiler emits the modern (chained) form. Mirrors
+///    `supports_implicit_standalone`/`supports_service_decorator`'s
+///    `map_or(true, …)`.
+/// 2. **Explicit pre-v21.0.4 falls back.** On Angular 19, 20, and
+///    v21.0.0–v21.0.3 the runtime query functions return `void`, so
+///    chained emit would throw at runtime. Consumers targeting those
+///    versions must pass `angular_version` explicitly to opt out of
+///    the chained form.
+#[test]
+fn test_query_chaining_obeys_angular_version_gate() {
+    let allocator = Allocator::default();
+
+    let source = r"
+import { Component, ViewChild, ElementRef } from '@angular/core';
+
+@Component({
+    selector: 'app-login',
+    template: '<input #a /><input #b /><input #c />',
+})
+export class LoginFormComponent {
+    @ViewChild('a') a: ElementRef;
+    @ViewChild('b') b: ElementRef;
+    @ViewChild('c') c: ElementRef;
+}
+";
+
+    // Versions where chained emit would crash at runtime — must produce
+    // three separate `ɵɵviewQuery(…)` statements.
+    let unsafe_versions: [AngularVersion; 3] = [
+        AngularVersion::new(19, 2, 0),
+        AngularVersion::new(20, 0, 0),
+        AngularVersion::new(21, 0, 3),
+    ];
+    for version in unsafe_versions {
+        let options =
+            ComponentTransformOptions { angular_version: Some(version), ..Default::default() };
+        let result =
+            transform_angular_file(&allocator, "login.component.ts", source, Some(&options), None);
+        assert!(!result.has_errors(), "v{version:?} should compile: {:?}", result.diagnostics);
+
+        let code = &result.code;
+        let root_calls = code.matches("ɵɵviewQuery(").count();
+        assert_eq!(
+            root_calls, 3,
+            "v{version:?}: expected 3 separate ɵɵviewQuery statements (chained emit \
+             unsafe pre-v21.0.4). Output:\n{code}"
+        );
+    }
+
+    // Versions where chained emit is safe — including `None` (assume
+    // latest) per the crate's convention.
+    let chained_versions: [Option<AngularVersion>; 3] =
+        [None, Some(AngularVersion::new(21, 0, 4)), Some(AngularVersion::new(22, 0, 0))];
+    for version in chained_versions {
+        let options = ComponentTransformOptions { angular_version: version, ..Default::default() };
+        let result =
+            transform_angular_file(&allocator, "login.component.ts", source, Some(&options), None);
+        let code = &result.code;
+        assert_eq!(
+            code.matches("ɵɵviewQuery(").count(),
+            1,
+            "v{version:?}: should chain — `None` defaults to assume-latest, \
+             v21.0.4+ has `typeof <fn>` return. Output:\n{code}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Chain consecutive same-kind query instructions (`ɵɵviewQuery(p1)(p2)`, `ɵɵcontentQuerySignal(...)(...)`) when the target Angular runtime supports it — matches upstream ngtsc's `instructionChainAfter()` emit pattern.
- Gate that chained emit behind a new `AngularVersion::supports_chained_queries()` predicate so consumers explicitly targeting v19/v20/v21.0.0–v21.0.3 can opt out and keep the safe separate-statement form. (The runtime functions returned `void` until v21.0.4; chaining on those versions throws at runtime.)
- Swap predicate-pooling order so content queries are pooled before view queries, aligning the `_c<N>` constant-table indices with upstream emit. Runtime-safe on every supported version.

## Compatibility (v19+)

Behavior across the currently-supported version range:

| Angular version | `ɵɵviewQuery` / `ɵɵcontentQuery` / `ɵɵ*Signal` return | Emit | Runtime |
|---|---|---|---|
| v19, v20, v21.0.0 – v21.0.3 (explicit) | `void` | separate statements (unchanged from current behavior) | safe |
| v21.0.4+ (cherry-pick) | `typeof <fn>` | chained | safe |
| v21.1.0+ / v22+ | `typeof <fn>` | chained | safe |
| version unknown (`None`) | — | chained (assume latest) | safe on v21.0.4+ |

The runtime contract changed in `angular/angular@ae1c0dc4` ("perf(compiler): chain query creation instructions", cherry-picked into v21.0.4 as `f901cc9e`). The existing comments in this codebase saying "Angular 20's `ɵɵviewQuery` returns void, so chaining is not supported" were correct on v20 and remain correct on v19/v20/v21.0.0–3 — this PR keeps that fallback path available to consumers who pass an explicit `angular_version`.

The first revision of this PR silently changed emit for every supported version, which would have broken v19/v20/v21.0.0–3 at runtime. This revision adds the version gate so the older fallback is reachable.

### `None` = assume latest

When `angular_version` is `None` the compiler emits the chained form, matching this crate's existing convention (`supports_implicit_standalone`, `supports_service_decorator`, etc. all use `map_or(true, …)` and the `transform.rs` comment reads `angular_version: None // assume latest`). Consumers targeting v19/v20/v21.0.0–3 already need to set `angular_version` explicitly to get the right emit for several other instructions (`ɵɵconditionalCreate` vs. `ɵɵtemplate`, `ɵɵdomProperty` vs. `ɵɵhostProperty`, etc.); the chained-query gate slots into the same opt-out pattern.

## Why

The Angular runtime source at v22 / v21.0.4+ shows all four query instructions return `typeof <fn>`:

- [`core/src/render3/instructions/queries.ts:40,58`](https://github.com/angular/angular/blob/22.1.0-next.0/packages/core/src/render3/instructions/queries.ts#L40-L61) (decorator queries)
- [`core/src/render3/instructions/queries_signals.ts:32,53`](https://github.com/angular/angular/blob/22.1.0-next.0/packages/core/src/render3/instructions/queries_signals.ts#L26-L56) (signal queries)

```ts
export function ɵɵcontentQuerySignal<T>(
  …
): typeof ɵɵcontentQuerySignal {
  bindQueryToSignal(target, createContentQuery(…));
  return ɵɵcontentQuerySignal;  // ← chainable
}
```

Upstream ngtsc chains consecutive same-instruction calls on those versions via `instructionChainAfter()`. Every compliance golden under [`signal_queries/`](https://github.com/angular/angular/tree/22.1.0-next.0/packages/compiler-cli/test/compliance/test_cases/signal_queries) and [`r3_compiler_compliance/components_and_directives/queries/`](https://github.com/angular/angular/tree/22.1.0-next.0/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries) emits the chained form.

The pool-ordering swap is a separate, runtime-safe fix: predicate pooling was running view queries first, so `_c0`/`_c1` ended up on view queries while Angular's goldens have them on content queries. One-line swap in `compile_component_full` puts content first, aligning const-table indices with every supported Angular version.

## What changes per file

**`crates/oxc_angular_compiler/src/component/metadata.rs`**
- Add `AngularVersion::supports_chained_queries()`. Matches the existing `supports_*` pattern. v22+ unconditionally, v21.1.0+ on the v21 line, v21.0.4+ on the v21.0 cherry-pick line. v19/v20 explicitly false.

**`crates/oxc_angular_compiler/src/directive/query.rs`**
- `create_view_queries_function` and `create_content_queries_function` gain an `Option<AngularVersion>` parameter. Chained-emit guard: `angular_version.map_or(true, |v| v.supports_chained_queries())` — `None` assumes latest (chained), explicit pre-v21.0.4 falls back to one expression statement per query.
- Consecutive same-`is_signal` queries fold via `call_fn(chain, params)`. The chain flushes when signal-ness flips (different runtime symbol — can't bridge the boundary) and at end-of-loop.
- Three unit tests rewritten to pass v22 and assert the chained form.

**`crates/oxc_angular_compiler/src/directive/compiler.rs`** and **`definition.rs`**
- `compile_directive`, `compile_directive_from_metadata`, `build_base_directive_fields`, `generate_directive_definitions`, and `generate_dir_definition` thread the new `Option<AngularVersion>` parameter through.

**`crates/oxc_angular_compiler/src/component/transform.rs`**
- Threads `options.angular_version` to the query builders and to `generate_directive_definitions`.
- Swaps the call order so content-query predicates are pooled before view-query predicates.

**`crates/oxc_angular_compiler/tests/integration_test.rs`**
- Three integration tests rewritten to pass v22 and assert chained output / boundary behavior.
- New `test_query_chaining_obeys_angular_version_gate` exercises both contracts in one place: explicit v19.2.0, v20.0.0, v21.0.3 each fall back to separate statements; `None`, v21.0.4, v22.0.0 all chain.

## Linker (intentionally untouched)

The linker (`linker/mod.rs`) processes partial declarations into final form without knowing the target runtime version, so chained emit there would be unsafe when the linked library ends up running on the v19/v20/v21.0.0–3 path. Worth revisiting once `build_queries` and its callers gain version awareness. The earlier revision of this PR did patch the linker; it's reverted here.

## Mixed signal + decorator behavior

Worth calling out: `ɵɵviewQuery` and `ɵɵviewQuerySignal` are different runtime symbols, so a chain *can't* cross that boundary. The implementation flushes the chain when `is_signal` flips between consecutive queries — same for content queries. `test_mixed_signal_and_decorator_view_queries_break_chain_on_boundary` covers this: two signal queries chain into one expression, then the single decorator query produces a separate root call.

## Test plan

- [x] `cargo test -p oxc_angular_compiler` — all ~2500 tests pass (1047 lib + 398 integration + remainder across other test files).
- [x] `cargo fmt --all -- --check` passes (clean rustfmt).
- [x] NAPI rebuild (`pnpm --filter ./napi/angular-compiler build`) succeeds.
- [x] End-to-end verification: linked the local NAPI build into [analogjs/analog](https://github.com/analogjs/analog)'s upstream-anchored parity suite (which compares output against Angular's compliance goldens) and passed `angularVersion: { major: 22, minor: 0, patch: 0 }` via the adapter. The `signal_queries/query_in_component` fixture — previously the one known OXC divergence — now matches Angular v22.1.0-next.0 byte-for-byte.
- [x] New regression test `test_query_chaining_obeys_angular_version_gate` asserts both contracts: explicit pre-v21.0.4 falls back, `None`/v21.0.4+/v22 chain.
