### PR TITLE
fix(partial): handle FactoryTarget::Service in partial factory emit

### DIFF
--- a/crates/oxc_angular_compiler/src/partial/factory.rs
+++ b/crates/oxc_angular_compiler/src/partial/factory.rs
@@ -175,7 +175,7 @@ fn factory_target_expr<'a>(
         FactoryTarget::Directive => "Directive",
         FactoryTarget::Pipe => "Pipe",
         FactoryTarget::NgModule => "NgModule",
-        FactoryTarget::Injectable => "Injectable",
+        FactoryTarget::Injectable | FactoryTarget::Service => "Injectable",
     };
 
     let factory_target_ref = OutputExpression::ReadProp(Box::new_in(


### PR DESCRIPTION
## Summary

Fixes a build break on `main` after #324 (`@Service` decorator AOT) and #325 (partial-declaration emit) landed sequentially.

#324 added a new `FactoryTarget::Service` enum variant. #325 added the partial factory emitter with an exhaustive match on `FactoryTarget`. Each PR passed CI on its own branch, but the new variant wasn't added to the match in the partial emitter — so `cargo build` on `main` now fails:

```
error[E0004]: non-exhaustive patterns: `FactoryTarget::Service` not covered
  --> crates/oxc_angular_compiler/src/partial/factory.rs:173:25
```

## Fix

Group `Service` with `Injectable` in the partial-emit match. At runtime, Service factories use the same `ɵɵinject` token path as Injectable — `factory/compiler.rs:664` already groups them in the full-mode dispatch — so the partial declaration's `target: i0.ɵɵFactoryTarget.Injectable` produces the correct linked factory.

```rust
- FactoryTarget::Injectable => "Injectable",
+ FactoryTarget::Injectable | FactoryTarget::Service => "Injectable",
```

## Test plan

- [x] `cargo build -p oxc_angular_compiler` — clean
- [x] `cargo test -p oxc_angular_compiler` — **2689 passed, 0 failed**
- [x] `pnpm build` (full native + tsc) — clean
- [ ] When `@Service` AOT gains its own partial-emit slice with a proper `ɵɵngDeclareService` shape, swap the match arm to a dedicated `"Service"` variant and add a `FactoryTarget::Service` test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)