### PR TITLE
fix(angular): error on unresolved templateUrl/styleUrl instead of silent passthrough

### DIFF
--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -2582,7 +2582,8 @@ pub fn transform_angular_file(
                     resolve_styles(allocator, &mut metadata, resolved_resources);
 
                 // 4. Resolve template from inline or external source
-                let template_source = resolve_template(&metadata, resolved_resources);
+                let (template_source, missing_template_url) =
+                    resolve_template(&metadata, resolved_resources);
                 let class_name = metadata.class_name.to_string();
 
                 // Resources were provided but a styleUrl was not among them:
@@ -2593,6 +2594,13 @@ pub fn transform_angular_file(
                         "Component '{}': style URL '{}' could not be resolved \
                          (COMPONENT_RESOURCE_NOT_FOUND)",
                         class_name, style_url
+                    )));
+                }
+                if let Some(template_url) = &missing_template_url {
+                    result.diagnostics.push(OxcDiagnostic::error(format!(
+                        "Component '{}': template URL '{}' could not be resolved \
+                         (COMPONENT_RESOURCE_NOT_FOUND)",
+                        class_name, template_url
                     )));
                 }
 
@@ -2860,7 +2868,9 @@ pub fn transform_angular_file(
                             result.diagnostics.extend(diags);
                         }
                     }
-                } else if let Some(template_url) = &metadata.template_url {
+                } else if missing_template_url.is_none()
+                    && let Some(template_url) = &metadata.template_url
+                {
                     // External template not resolved: the class is emitted
                     // without its compiled definition, so fail loudly like
                     // ngc's COMPONENT_RESOURCE_NOT_FOUND instead of letting
@@ -4024,22 +4034,23 @@ fn compile_component_full<'a>(
 fn resolve_template(
     metadata: &ComponentMetadata<'_>,
     resources: Option<&ResolvedResources>,
-) -> Option<String> {
-    // ngc AOT precedence: templateUrl first, falling through to inline only when
-    // no resolved content is available.
+) -> (Option<String>, Option<String>) {
+    // ngc AOT precedence: templateUrl first. When resources were supplied, a
+    // missing entry is reported to the caller instead of falling back to inline.
     if let Some(template_url) = &metadata.template_url {
         if let Some(resources) = resources {
             if let Some(template) = resources.templates.get(template_url.as_str()) {
-                return Some(template.clone());
+                return (Some(template.clone()), None);
             }
+            return (None, Some(template_url.to_string()));
         }
     }
 
     if let Some(template) = &metadata.template {
-        return Some(template.to_string());
+        return (Some(template.to_string()), None);
     }
 
-    None
+    (None, None)
 }
 
 /// Resolve external styles and merge into component metadata.

--- a/crates/oxc_angular_compiler/src/component/transform.rs
+++ b/crates/oxc_angular_compiler/src/component/transform.rs
@@ -2578,11 +2578,23 @@ pub fn transform_angular_file(
                 }
 
                 // 3. Resolve external styles and merge into metadata
-                resolve_styles(allocator, &mut metadata, resolved_resources);
+                let missing_style_urls =
+                    resolve_styles(allocator, &mut metadata, resolved_resources);
 
                 // 4. Resolve template from inline or external source
                 let template_source = resolve_template(&metadata, resolved_resources);
                 let class_name = metadata.class_name.to_string();
+
+                // Resources were provided but a styleUrl was not among them:
+                // fail loudly like ngc (COMPONENT_RESOURCE_NOT_FOUND) instead
+                // of silently dropping the styles (#314).
+                for style_url in &missing_style_urls {
+                    result.diagnostics.push(OxcDiagnostic::error(format!(
+                        "Component '{}': style URL '{}' could not be resolved \
+                         (COMPONENT_RESOURCE_NOT_FOUND)",
+                        class_name, style_url
+                    )));
+                }
 
                 if let Some(template_string) = template_source {
                     // Allocate template in arena so it has the allocator's lifetime.
@@ -2849,10 +2861,15 @@ pub fn transform_angular_file(
                         }
                     }
                 } else if let Some(template_url) = &metadata.template_url {
-                    // External template not resolved - add warning
-                    result.diagnostics.push(OxcDiagnostic::warn(format!(
-                        "Template URL '{}' not found in resolved resources",
-                        template_url
+                    // External template not resolved: the class is emitted
+                    // without its compiled definition, so fail loudly like
+                    // ngc's COMPONENT_RESOURCE_NOT_FOUND instead of letting
+                    // the build ship a broken component (#314).
+                    result.diagnostics.push(OxcDiagnostic::error(format!(
+                        "Component '{}': template URL '{}' could not be resolved \
+                         (COMPONENT_RESOURCE_NOT_FOUND); the component was emitted \
+                         without its compiled definition",
+                        class_name, template_url
                     )));
                 }
             } else {
@@ -4026,12 +4043,18 @@ fn resolve_template(
 }
 
 /// Resolve external styles and merge into component metadata.
+///
+/// Returns the styleUrls that were NOT found in `resources` (only when
+/// resources were provided), so the caller can surface a
+/// COMPONENT_RESOURCE_NOT_FOUND diagnostic per missing resource.
 fn resolve_styles<'a>(
     allocator: &'a Allocator,
     metadata: &mut ComponentMetadata<'a>,
     resources: Option<&ResolvedResources>,
-) {
+) -> Vec<String> {
     use oxc_allocator::FromIn;
+
+    let mut missing = Vec::new();
 
     if let Some(resources) = resources {
         // Resolve each styleUrl from the resources
@@ -4041,9 +4064,13 @@ fn resolve_styles<'a>(
                 for style in style_contents {
                     metadata.styles.push(Ident::from_in(style.as_str(), allocator));
                 }
+            } else {
+                missing.push(style_url.to_string());
             }
         }
     }
+
+    missing
 }
 
 /// Compile a component template to JavaScript.

--- a/crates/oxc_angular_compiler/tests/class_metadata_resources_test.rs
+++ b/crates/oxc_angular_compiler/tests/class_metadata_resources_test.rs
@@ -759,3 +759,79 @@ export class SpreadComponent {}
         "Resolved template content must be present. Got:\n{metadata}"
     );
 }
+
+/// An unresolved `templateUrl` must produce a hard error (ngc parity:
+/// COMPONENT_RESOURCE_NOT_FOUND), not a silent passthrough that ships a
+/// component without its compiled definition. Regression test for #314.
+#[test]
+fn unresolved_templateurl_is_a_hard_error() {
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-external',
+    templateUrl: './missing.component.html',
+})
+export class ExternalComponent {}
+"#;
+
+    // Resources provided, but the templateUrl is not among them.
+    let resources = ResolvedResources { templates: HashMap::new(), styles: HashMap::new() };
+    let allocator = Allocator::default();
+    let result = transform_angular_file(
+        &allocator,
+        "test.component.ts",
+        source,
+        Some(&TransformOptions::default()),
+        Some(&resources),
+    );
+
+    assert!(
+        result.has_errors(),
+        "Unresolved templateUrl must error. Got: {:?}",
+        result.diagnostics
+    );
+    let rendered = format!("{:?}", result.diagnostics);
+    assert!(
+        rendered.contains("COMPONENT_RESOURCE_NOT_FOUND"),
+        "Error should carry the ngc-style code. Got: {rendered}"
+    );
+    assert!(
+        rendered.contains("ExternalComponent") && rendered.contains("./missing.component.html"),
+        "Error should name the component and the resource. Got: {rendered}"
+    );
+}
+
+/// An unresolved `styleUrl` (resources provided, key missing) must also
+/// surface a COMPONENT_RESOURCE_NOT_FOUND error rather than silently
+/// dropping the styles. Regression test for #314.
+#[test]
+fn unresolved_styleurl_is_a_hard_error() {
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-styled',
+    template: '<div></div>',
+    styleUrls: ['./missing.css'],
+})
+export class StyledComponent {}
+"#;
+
+    let resources = ResolvedResources { templates: HashMap::new(), styles: HashMap::new() };
+    let allocator = Allocator::default();
+    let result = transform_angular_file(
+        &allocator,
+        "test.component.ts",
+        source,
+        Some(&TransformOptions::default()),
+        Some(&resources),
+    );
+
+    assert!(result.has_errors(), "Unresolved styleUrl must error. Got: {:?}", result.diagnostics);
+    let rendered = format!("{:?}", result.diagnostics);
+    assert!(
+        rendered.contains("COMPONENT_RESOURCE_NOT_FOUND") && rendered.contains("./missing.css"),
+        "Error should carry the code and the resource. Got: {rendered}"
+    );
+}

--- a/crates/oxc_angular_compiler/tests/class_metadata_resources_test.rs
+++ b/crates/oxc_angular_compiler/tests/class_metadata_resources_test.rs
@@ -802,6 +802,52 @@ export class ExternalComponent {}
     );
 }
 
+/// If both `templateUrl` and inline `template` are present, a missing resolved
+/// templateUrl must still be an error. AOT semantics give `templateUrl`
+/// precedence, so the inline template cannot be used as a fallback.
+#[test]
+fn unresolved_templateurl_with_inline_template_is_a_hard_error() {
+    let source = r#"
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-external',
+    templateUrl: './missing.component.html',
+    template: '<p>inline fallback must not compile</p>',
+})
+export class ExternalComponent {}
+"#;
+
+    let resources = ResolvedResources { templates: HashMap::new(), styles: HashMap::new() };
+    let allocator = Allocator::default();
+    let result = transform_angular_file(
+        &allocator,
+        "test.component.ts",
+        source,
+        Some(&TransformOptions::default()),
+        Some(&resources),
+    );
+
+    assert!(
+        result.has_errors(),
+        "Unresolved templateUrl must error even with an inline template. Got: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(
+        result.component_count, 0,
+        "Inline template must not be used to compile the component"
+    );
+    let rendered = format!("{:?}", result.diagnostics);
+    assert!(
+        rendered.contains("COMPONENT_RESOURCE_NOT_FOUND"),
+        "Error should carry the ngc-style code. Got: {rendered}"
+    );
+    assert!(
+        rendered.contains("ExternalComponent") && rendered.contains("./missing.component.html"),
+        "Error should name the component and the resource. Got: {rendered}"
+    );
+}
+
 /// An unresolved `styleUrl` (resources provided, key missing) must also
 /// surface a COMPONENT_RESOURCE_NOT_FOUND error rather than silently
 /// dropping the styles. Regression test for #314.

--- a/crates/oxc_angular_compiler/tests/integration_test.rs
+++ b/crates/oxc_angular_compiler/tests/integration_test.rs
@@ -3276,7 +3276,12 @@ export class MatMiniFabButton {
     let mut templates = std::collections::HashMap::new();
     templates.insert("button.html".to_string(), button_template.to_string());
 
-    let resources = ResolvedResources { templates, styles: std::collections::HashMap::new() };
+    // Both components also declare `styleUrl: 'fab.css'`; provide it so the
+    // fixture stays fully resolved now that missing resources are hard errors.
+    let mut styles = std::collections::HashMap::new();
+    styles.insert("fab.css".to_string(), vec![".fab {}".to_string()]);
+
+    let resources = ResolvedResources { templates, styles };
 
     let result = transform_angular_file(&allocator, "fab.ts", source, None, Some(&resources));
 


### PR DESCRIPTION
## Summary
An unresolved `templateUrl` or `styleUrl` now produces a hard error diagnostic (`COMPONENT_RESOURCE_NOT_FOUND`, naming the component class and the resource) instead of a silent passthrough. The diagnostic flows through the existing `result.diagnostics` -> NAPI `result.errors` path, so vite/esbuild builds fail loudly rather than shipping a class without its `ɵcmp`/`ɵfac`.

## Why this matters
#314: when resource resolution fails, OXC returned the source unchanged - "the build 'succeeds,' ng dev/build prints no warning, and the breakage only shows up at runtime as an uninstantiable component." ngc raises a clear diagnostic in the same situation.

Two changes in `crates/oxc_angular_compiler/src/component/transform.rs`:
- the unresolved-`templateUrl` branch upgrades its vague warning ("Template URL '...' not found in resolved resources") to an error carrying the ngc-style code, the class name, and an explicit note that the component was emitted without its compiled definition
- `resolve_styles` now reports styleUrls that were missing from the provided resources (previously dropped silently), and each missing one surfaces the same `COMPONENT_RESOURCE_NOT_FOUND` error; when no resources are passed at all, style behavior is unchanged

This covers the loud-failure bar from the issue's "Required work" item 1. Item 2 (graceful folding of unresolvable `${...}` template-literal references) is a separate codepath and is left for a follow-up so this stays reviewable.

## Testing
- New `unresolved_templateurl_is_a_hard_error` and `unresolved_styleurl_is_a_hard_error` regression tests in `class_metadata_resources_test.rs` assert `has_errors()`, the error code, and that the message names the class and resource
- `test_multi_component_external_template_unique_const_names` now supplies its declared `fab.css` resource - under the new semantics its previously half-resolved fixture correctly errored, which is the behavior change working as intended
- Full `cargo test -p oxc_angular_compiler`: 2700 passed, 0 failed; `cargo fmt --check` clean
- The existing NAPI test `should handle external template URLs with warning` already asserts `result.errors.length > 0` for the unresolved case and is unaffected (all diagnostics map to `errors`)

Fixes #314
