### PR TITLE
chore: config minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,30 @@ allowBuilds:
   msgpackr-extract: true
   protobufjs: true
 
+minimumReleaseAgeExclude:
+  - '@napi-rs/*'
+  - '@oxc-node/*'
+  - '@oxc-minify/*'
+  - '@oxc-parser/*'
+  - '@oxc-project/*'
+  - '@oxc-resolver/*'
+  - '@oxc-transform/*'
+  - '@oxfmt/*'
+  - '@oxlint-tsgolint/*'
+  - '@oxlint/*'
+  - '@rolldown/*'
+  - '@tsdown/*'
+  - '@types/*'
+  - '@vitejs/*'
+  - '@vitest/*'
+  - '@voidzero-dev/*'
+  - oxc-minify
+  - oxc-parser
+  - oxc-transform
+  - oxfmt
+  - oxlint
+  - oxlint-tsgolint
+
 catalog:
   '@napi-rs/cli': 3.7.2
   '@oxc-node/cli': 0.1.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workspace-only pnpm policy change with no runtime or application code impact.
> 
> **Overview**
> Adds a **`minimumReleaseAgeExclude`** list to `pnpm-workspace.yaml` so pnpm’s minimum-release-age policy does not apply to selected dependencies.
> 
> The exclusions cover the repo’s **toolchain and build stack**: `@napi-rs/*`, Oxc/Oxlint/Oxfmt packages, Rolldown, tsdown, `@types/*`, Vite/Vitest, and related scoped packages, plus a few unscoped Oxc/Oxlint package names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bdd2501fe6063110e12fbdd07ecbce04110b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->