### PR TITLE
0.0.33

### DIFF
--- a/napi/angular-compiler/index.js
+++ b/napi/angular-compiler/index.js
@@ -83,12 +83,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-android-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -106,12 +106,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-android-arm-eabi/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -141,12 +141,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-win32-x64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -164,12 +164,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-win32-x64-msvc/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -188,12 +188,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-win32-ia32-msvc/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -211,12 +211,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-win32-arm64-msvc/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -237,12 +237,12 @@ function requireNative() {
       const bindingPackageVersion =
         require('@oxc-angular/binding-darwin-universal/package.json').version
       if (
-        bindingPackageVersion !== '0.0.32' &&
+        bindingPackageVersion !== '0.0.33' &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+          `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
         )
       }
       return binding
@@ -260,12 +260,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-darwin-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -283,12 +283,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-darwin-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -310,12 +310,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-freebsd-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -333,12 +333,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-freebsd-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -361,12 +361,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-x64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -384,12 +384,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-x64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -409,12 +409,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -432,12 +432,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -457,12 +457,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm-musleabihf/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -480,12 +480,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm-gnueabihf/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -505,12 +505,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-loong64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -528,12 +528,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-loong64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -553,12 +553,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-riscv64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -576,12 +576,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-riscv64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.32' &&
+            bindingPackageVersion !== '0.0.33' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -600,12 +600,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-linux-ppc64-gnu/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -623,12 +623,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-linux-s390x-gnu/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -650,12 +650,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -673,12 +673,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -696,12 +696,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-arm/package.json').version
         if (
-          bindingPackageVersion !== '0.0.32' &&
+          bindingPackageVersion !== '0.0.33' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.33 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding

--- a/napi/angular-compiler/package.json
+++ b/napi/angular-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-angular/vite",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Oxc Angular Compiler Vite plugin",
   "keywords": [
     "angular",


### PR DESCRIPTION
## Summary
- bump @oxc-angular/vite to 0.0.33
- update generated native binding version checks to 0.0.33

## Validation
- pnpm --filter ./napi/angular-compiler build:ts
- pnpm --filter ./napi/angular-compiler test
- cargo check --all-features
- git diff --check

Note: local `pnpm check` exited 1 after traversing nested node_modules dependency files; latest main CI is green on 9d249f5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version bump with synchronized binding checks; no functional code changes beyond release metadata.
> 
> **Overview**
> Releases **@oxc-angular/vite** as **0.0.33** by updating `napi/angular-compiler/package.json`.
> 
> The auto-generated `napi/angular-compiler/index.js` loader now expects **`@oxc-angular/binding-*` optional packages at 0.0.33** everywhere it compares `bindingPackageVersion` (when `NAPI_RS_ENFORCE_VERSION_CHECK` is enabled), including mismatch error text. No loader logic beyond the version string changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849f73586d6bd6c2421f663c88cc414941f38fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->