### PR TITLE
fix(lexer): consume newlines between `@let` and the declared name

### DIFF
--- a/crates/oxc_angular_compiler/src/parser/html/lexer.rs
+++ b/crates/oxc_angular_compiler/src/parser/html/lexer.rs
@@ -1205,8 +1205,12 @@ impl<'a> HtmlLexer<'a> {
         for _ in 0..4 {
             self.advance();
         }
-        // Skip whitespace (but not newlines for detecting invalid @let)
-        while self.peek() == ' ' || self.peek() == '\t' {
+        // Skip whitespace after `@let`, including newlines. Angular consumes all
+        // whitespace between `@let` and the declared name, so `@let\nfoo = ...;` is a
+        // valid declaration. Stopping at a newline here misclassified it as incomplete,
+        // leaving the value (and any object-literal braces in it) to be re-lexed as
+        // block content, which corrupted block nesting.
+        while chars::is_whitespace(self.peek()) {
             self.advance();
         }
 

--- a/crates/oxc_angular_compiler/tests/html_lexer_test.rs
+++ b/crates/oxc_angular_compiler/tests/html_lexer_test.rs
@@ -1603,6 +1603,27 @@ mod let_declarations {
         // Should also have LET_VALUE
         assert!(types.contains(&HtmlTokenType::LetValue));
     }
+
+    #[test]
+    fn should_tokenize_let_declaration_with_newline_before_name() {
+        // Angular allows any whitespace - including newlines - between `@let` and the
+        // declared name (it skips whitespace via `isNotWhitespace`). A newline there must
+        // still produce a complete declaration, not an incomplete one.
+        let result = tokenize("@let\nfoo = 123;");
+
+        let types: Vec<_> = result.tokens.iter().map(|t| t.token_type).collect();
+
+        assert!(types.contains(&HtmlTokenType::LetStart), "Should have LetStart, got {types:?}");
+        assert!(types.contains(&HtmlTokenType::LetValue), "Should have LetValue, got {types:?}");
+        assert!(types.contains(&HtmlTokenType::LetEnd), "Should have LetEnd, got {types:?}");
+        assert!(
+            !types.contains(&HtmlTokenType::IncompleteLet),
+            "Should not be treated as incomplete, got {types:?}"
+        );
+
+        let let_start = result.tokens.iter().find(|t| t.token_type == HtmlTokenType::LetStart);
+        assert_eq!(let_start.unwrap().value(), "foo");
+    }
 }
 
 // ============================================================================

--- a/crates/oxc_angular_compiler/tests/html_parser_test.rs
+++ b/crates/oxc_angular_compiler/tests/html_parser_test.rs
@@ -797,6 +797,21 @@ mod let_declarations {
         let result = parse_and_humanize_no_ws("@let a = 1; @let b = 2;");
         assert_eq!(result, vec![let_decl("a"), let_decl("b")]);
     }
+
+    #[test]
+    fn should_parse_let_with_object_literal_value_and_newline_in_block() {
+        // Regression: when `@let` was followed by a newline (as prettier formats it), the
+        // declaration was misclassified as incomplete, so its value was never consumed. The
+        // object-literal braces in the value were then re-lexed as a stray block close,
+        // corrupting block nesting and surfacing as an "Unexpected closing tag" error.
+        let result = parse_and_humanize_no_ws(
+            "@if (cond) { @let\nlabel = value | translate: { section: id }; <button></button> }",
+        );
+        assert!(
+            result.iter().any(|n| n == &let_decl("label")),
+            "Expected a LetDeclaration named 'label', got {result:?}"
+        );
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The HTML lexer misclassifies a `@let` declaration as incomplete when a
newline (rather than a space/tab) separates the `@let` keyword from the
declared name — e.g. when a formatter wraps the line:

```html
@if (cond) { @let
  label = value | translate: { section: id };
  <button></button>
}
```

Because the declaration is treated as incomplete, its value is never
consumed. Any object-literal braces inside the value (`{ section: id }`) are
then re-lexed as ordinary block content, and the stray `}` becomes a
spurious block-close token. That corrupts block nesting and surfaces
downstream as an `Unexpected closing block` / `Unexpected closing tag` parse
error, failing the build for otherwise-valid Angular templates.

The standard `@angular/compiler` accepts this template, so the divergence is
in the lexer's whitespace handling.

## Root cause

`scan_let_start` (`crates/oxc_angular_compiler/src/parser/html/lexer.rs`)
skipped only spaces and tabs after `@let`:

```rust
while self.peek() == ' ' || self.peek() == '\t' {
    self.advance();
}
```

When the next character is a newline, the following name-start check fails and
the scanner emits `IncompleteLet`, bailing before it reads the value.

## Alignment with Angular

Angular's `_consumeLetDeclaration`
(`packages/compiler/src/ml_parser/lexer.ts`, v22.1.0-rc.0) requires at least
one whitespace after `@let` and then consumes **all** whitespace via
`_attemptCharCodeUntilFn(isNotWhitespace)`:

```ts
// Require at least one white space after the `@let`.
if (chars.isWhitespace(this._cursor.peek())) {
  this._attemptCharCodeUntilFn(isNotWhitespace);
} else {
  ... INCOMPLETE_LET; return;
}
```

`isWhitespace` is `(code >= $TAB && code <= $SPACE) || code == $NBSP`, which
includes `\n` and `\r`. The "require at least one whitespace" half is already
enforced by this crate's block dispatch (`@letFoo` → `IncompleteLet`); only
the "skip all whitespace" half was too strict.

## Fix

Skip all whitespace after `@let`, matching Angular:

```rust
while chars::is_whitespace(self.peek()) {
    self.advance();
}
```

`chars::is_whitespace` here is `matches!(ch, TAB..=SPACE | NBSP)` — the same
range as Angular's `isWhitespace`. `EOF` (`'\0'`) is outside that range, so
the loop still terminates at end-of-input, matching Angular's
`isNotWhitespace` EOF guard.

## Tests

- **Lexer** (`html_lexer_test.rs`) — `@let\nfoo = 123;` tokenizes as a
  complete `LetStart` / `LetValue` / `LetEnd` (not `IncompleteLet`).
- **Parser** (`html_parser_test.rs`) — a `@let` with an object-literal value
  inside a block no longer corrupts block nesting (regression for the
  `Unexpected closing block` error).

Both fail before the change and pass after. Full suite green:
`cargo test -p oxc_angular_compiler` — 0 failures. `cargo fmt` clean.
