### PR TITLE
fix(linker): unwrap namespaced `forwardRef()` in partial declarations

### DIFF
--- a/crates/oxc_angular_compiler/src/linker/mod.rs
+++ b/crates/oxc_angular_compiler/src/linker/mod.rs
@@ -525,6 +525,11 @@ fn extract_forward_ref<'a>(expr: &Expression<'a>, source: &'a str) -> (&'a str, 
     if let Expression::CallExpression(call) = expr {
         let is_forward_ref = match &call.callee {
             Expression::Identifier(ident) => ident.name == "forwardRef",
+            // Angular's own fesm bundles reach core through a namespace import, so
+            // they ship `i0.forwardRef(...)` rather than a bare call. The TS linker
+            // matches on `callee.getSymbolName()`, which returns the property name
+            // for a member expression, so both forms have to unwrap here too.
+            Expression::StaticMemberExpression(member) => member.property.name == "forwardRef",
             _ => false,
         };
         if is_forward_ref {
@@ -4159,6 +4164,227 @@ MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "
         assert!(
             result.code.contains("providedIn: SomeModule"),
             "providedIn should have forwardRef unwrapped, got:\n{}",
+            result.code
+        );
+    }
+
+    // Angular's own fesm bundles reference core through the `i0` namespace import,
+    // so every forwardRef they ship is `i0.forwardRef(...)` rather than a bare
+    // `forwardRef(...)`. The TS linker matches on `callee.getSymbolName()`, which
+    // returns the property name for a member expression, so both forms unwrap.
+
+    #[test]
+    fn test_link_injectable_namespaced_forward_ref_use_class() {
+        // Mirrors `@angular/forms/signals`' InputValidityMonitor, whose root provider
+        // is declared as `useClass: i0.forwardRef(() => AnimationInputValidityMonitor)`.
+        // Leaving the wrapper in place emits `forwardRef(() => X).ɵfac(...)`, and
+        // `forwardRef` returns the arrow function it was handed — so `.ɵfac` is
+        // undefined and the provider throws the first time it is instantiated.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class InputValidityMonitor {}
+InputValidityMonitor.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: InputValidityMonitor, providedIn: 'root', useClass: i0.forwardRef(() => AnimationInputValidityMonitor) });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("AnimationInputValidityMonitor.ɵfac(__ngFactoryType__)"),
+            "Should delegate to the unwrapped class's factory, got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("forwardRef"),
+            "Should NOT contain forwardRef wrapper, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_injectable_namespaced_forward_ref_provided_in() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyService {}
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: MyService, providedIn: i0.forwardRef(() => SomeModule) });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("providedIn: SomeModule"),
+            "providedIn should have forwardRef unwrapped, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_injectable_namespaced_forward_ref_use_existing() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyService {}
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: MyService, useExisting: i0.forwardRef(() => OtherService) });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("ɵɵinject(OtherService)"),
+            "useExisting should have forwardRef unwrapped, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_injectable_namespaced_forward_ref_use_value() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyService {}
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: MyService, useValue: i0.forwardRef(() => DEFAULT_CONFIG) });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("DEFAULT_CONFIG"),
+            "useValue should have forwardRef unwrapped, got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("forwardRef"),
+            "Should NOT contain forwardRef wrapper, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_injectable_namespaced_forward_ref_use_class_with_deps() {
+        // `useClass` + `deps` takes the delegated-conditional-factory path, which
+        // instantiates via `new (useClass)(...)` rather than delegating to `ɵfac`.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyService {}
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: MyService, useClass: i0.forwardRef(() => OtherService), deps: [{ token: Dep1 }] });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("new (OtherService)"),
+            "useClass-with-deps should instantiate the unwrapped class, got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("forwardRef"),
+            "Should NOT contain forwardRef wrapper, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_query_predicate_namespaced_forward_ref() {
+        // TS linker: `predicate = extractForwardRef(predicateExpr)` in
+        // partial_directive_linker_1.ts, so query predicates unwrap too.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyComp {}
+MyComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "20.0.0", ngImport: i0, type: MyComp, selector: "my-comp", template: "<div></div>", isStandalone: true, viewQueries: [{ propertyName: "child", first: true, predicate: i0.forwardRef(() => ChildDir), descendants: true }] });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            !result.code.contains("forwardRef"),
+            "Query predicate should have forwardRef unwrapped, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("ChildDir"),
+            "Query predicate should reference the unwrapped type, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_component_old_style_pipes_namespaced_forward_ref() {
+        // v12–v13 partial declarations use a `pipes` object rather than the
+        // unified `dependencies` array — a separate extract_forward_ref call site.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyComp {}
+MyComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "12.0.0", ngImport: i0, type: MyComp, selector: "my-comp", template: "<div></div>", pipes: { "myPipe": i0.forwardRef(() => MyPipe) } });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            !result.code.contains("forwardRef"),
+            "Old-style pipes should have forwardRef unwrapped, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("dependencies: () => [MyPipe]"),
+            "forwardRef in pipes should force closure emit mode, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_injectable_use_factory_forward_ref_is_not_unwrapped() {
+        // Guard: the TS linker reads `useFactory` with `getOpaque()`, deliberately
+        // NOT `extractForwardRef` — a factory is already lazy, so unwrapping it
+        // would change evaluation order. Keep the wrapper.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyService {}
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: MyService, useFactory: i0.forwardRef(() => makeService) });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("forwardRef"),
+            "useFactory must keep its forwardRef wrapper, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_injectable_non_forward_ref_member_call_is_untouched() {
+        // Guard against over-matching: only a callee *named* `forwardRef` unwraps.
+        // Any other member call is passed through verbatim.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyService {}
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "20.0.0", ngImport: i0, type: MyService, useValue: config.getDefault(() => Fallback) });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            result.code.contains("config.getDefault(() => Fallback)"),
+            "Non-forwardRef call should pass through verbatim, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_component_dependency_namespaced_forward_ref() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyComp {}
+MyComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "20.0.0", ngImport: i0, type: MyComp, selector: "my-comp", template: "<div></div>", isStandalone: true, dependencies: [{ kind: "directive", type: i0.forwardRef(() => FooDir), selector: "foo" }] });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked, "Should have linked");
+        assert!(
+            !result.code.contains("forwardRef"),
+            "Should NOT contain forwardRef, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("dependencies: () => [FooDir]"),
+            "Should wrap deps in closure when forwardRef detected, got:\n{}",
             result.code
         );
     }

--- a/napi/angular-compiler/test/linker.test.ts
+++ b/napi/angular-compiler/test/linker.test.ts
@@ -198,3 +198,53 @@ describe('Linker transform filter matching', () => {
     expect(matches('src/app/app.component.ts')).toBe(false)
   })
 })
+
+/**
+ * Angular's own FESM bundles reach core through a namespace import, so every
+ * forwardRef they ship is `i0.forwardRef(...)` rather than a bare call. The TS
+ * linker matches on `callee.getSymbolName()`, which returns the property name
+ * for a member expression, so both forms must unwrap.
+ *
+ * Verbatim shape from `@angular/forms/fesm2022/signals.mjs`. Leaving the wrapper
+ * in place emits `forwardRef(() => X).ɵfac(t)`; `forwardRef` returns the arrow
+ * function it was handed, so `.ɵfac` is undefined and the provider throws the
+ * first time it is instantiated — which is every `[formField]` render.
+ */
+const NAMESPACED_FORWARD_REF_INJECTABLE = `
+import * as i0 from '@angular/core';
+
+class InputValidityMonitor {
+  static ɵfac = i0.ɵɵngDeclareFactory({
+    minVersion: "12.0.0",
+    version: "22.0.7",
+    ngImport: i0,
+    type: InputValidityMonitor,
+    deps: [],
+    target: i0.ɵɵFactoryTarget.Injectable
+  });
+  static ɵprov = i0.ɵɵngDeclareInjectable({
+    minVersion: "12.0.0",
+    version: "22.0.7",
+    ngImport: i0,
+    type: InputValidityMonitor,
+    providedIn: 'root',
+    useClass: i0.forwardRef(() => AnimationInputValidityMonitor)
+  });
+}
+class AnimationInputValidityMonitor extends InputValidityMonitor {}
+export { InputValidityMonitor };
+`
+
+describe('linker: namespaced forwardRef', () => {
+  it('unwraps `i0.forwardRef()` in useClass so the factory delegates to a real class', () => {
+    const result = linkAngularPackageSync(
+      NAMESPACED_FORWARD_REF_INJECTABLE,
+      '/node_modules/@angular/forms/fesm2022/signals.mjs',
+    )
+
+    expect(result.linked).toBe(true)
+    expect(result.code).toContain('AnimationInputValidityMonitor.ɵfac(__ngFactoryType__)')
+    // `forwardRef(...).ɵfac` is always a TypeError — the wrapper returns the arrow function.
+    expect(result.code).not.toMatch(/forwardRef\(\(\)\s*=>\s*\w+\)\.ɵfac/)
+  })
+})


### PR DESCRIPTION
## Summary

The linker only unwrapped a bare `forwardRef(...)` identifier callee, so the namespaced form Angular actually ships in its FESM bundles (`i0.forwardRef(...)`) fell through unresolved.

`extract_forward_ref` matched on:

```rust
Expression::Identifier(ident) => ident.name == "forwardRef",
_ => false,
```

Angular's `extractForwardRef` matches on `callee.getSymbolName()`, and `TypeScriptAstHost.getSymbolName` returns the property name for a property access, so `i0.forwardRef` resolves to `"forwardRef"` there. This adds the equivalent `StaticMemberExpression` arm.

## Impact

Left wrapped, `useClass` links to `forwardRef(() => X).ɵfac(t)`. `forwardRef` returns the very arrow function it was handed, so `.ɵfac` is `undefined`:

```
TypeError: forwardRef(...).ɵfac is not a function
```

That takes out **every `[formField]` render** in `@angular/forms/signals`, whose `InputValidityMonitor` root provider is declared exactly that way:

```js
static ɵprov = i0.ɵɵngDeclareInjectable({
  type: InputValidityMonitor,
  providedIn: 'root',
  useClass: i0.forwardRef(() => AnimationInputValidityMonitor)
});
```

Side by side on that input:

```js
// official @angular/compiler-cli linker
factory: __ngFactoryType__ => AnimationInputValidityMonitor.ɵfac(__ngFactoryType__)

// oxc, before this change
factory: function InputValidityMonitor_Factory(__ngFactoryType__) {
  return i0.forwardRef(() => AnimationInputValidityMonitor).ɵfac(__ngFactoryType__);
}
```

All seven `extract_forward_ref` call sites were affected: `providedIn`, `useClass` (with and without deps), `useExisting`, `useValue`, query predicates, and component dependencies.

**Query predicates fail the most quietly.** The runtime never resolves forward refs in a predicate (no `resolveForwardRef` anywhere under `packages/core/src/render3/queries/`), so an unresolved one simply never matches and the query comes back empty, with nothing logged. Scanning a real `node_modules`, 9 partial-compiled bundles ship namespaced forwardRefs, including the content queries in `@angular/material`'s radio, tabs and button-toggle. `@angular/platform-browser`'s `DomSanitizer` happened to survive only because `ɵɵinject` resolves forward refs on the token itself.

This looks related to the `[formField]` breakage in #229, though that one was fixed separately by #232.

## Tests

Ten Rust tests covering every call site, plus one JS test through the napi boundary using the verbatim `@angular/forms/signals` shape.

Two of the ten are guards rather than regressions, and pass with or without the fix by design:

- `useFactory` must **keep** its wrapper (the TS linker reads it with `getOpaque()`, deliberately not `extractForwardRef`, since a factory is already lazy)
- a non-`forwardRef` member call such as `config.getDefault(...)` must pass through verbatim, guarding against over-matching

Reverting the one-line fix turns the other eight red.

## Verification

Every CI step run locally on macOS:

| Step | Result |
| --- | --- |
| `cargo check --all-features` | pass |
| `cargo test` | pass |
| `cargo fmt --all -- --check` | pass |
| `cargo run -p oxc_angular_conformance` | 1264/1264 (100%), snapshot byte-identical |
| `pnpm build-dev` + `build:ts` | pass |
| `pnpm test` | 201/201 |
| `pnpm check` | pass |
| `pnpm test:e2e` | 34/34 |
| `compare --fixtures` | 100% |

End to end: built the napi binding, ran it over the real `@angular/forms/fesm2022/signals.mjs`, confirmed the emit now matches the official linker, then dropped that binding into a large Angular 22 workspace where the signal-forms component tests went from a hard crash to passing.

## Note

`compare --fixtures` reports 100% throughout, because the compare harness covers source to AOT compilation and has no `ngDeclare` fixtures. The linker has no differential coverage against the official linker today, which is how this went unnoticed. A partial-declaration category in that harness would likely be worth having, but it is well outside the scope of this change.
