### PR TITLE
fix(linker): resolve `changeDetection` default from the declaration version

### DIFF
--- a/crates/oxc_angular_compiler/src/linker/mod.rs
+++ b/crates/oxc_angular_compiler/src/linker/mod.rs
@@ -2083,11 +2083,15 @@ fn link_component(
     if let Some(cd) = get_property_source(meta, "changeDetection", source) {
         if cd.contains("Eager") || cd.contains("Default") {
             parts.push("changeDetection: 1".to_string());
+        } else if cd.contains("OnPush") {
+            // Emitted explicitly rather than left to the runtime default. The TS
+            // compiler omits OnPush here, but it ships with the runtime it targets;
+            // this linker does not know the consumer's version and supports back to
+            // v19. Pre-v22 runtimes compute `onPush = changeDetection === OnPush`,
+            // so an absent field reads as Default there and the component would
+            // silently lose OnPush. `0` is correct on both.
+            parts.push("changeDetection: 0".to_string());
         }
-        // OnPush is the emit-time default and is left out: the runtime derives
-        // `onPush = changeDetection !== Eager`, so an absent field already reads
-        // as OnPush. Matches the `meta.changeDetection !== OnPush` guard in
-        // `compileComponentFromMetadata`.
     } else if !has_on_push_by_default(meta) {
         // Omitted. Which strategy that meant depends on the version the library
         // was compiled against, and the runtime reads an absent field as OnPush,
@@ -2770,12 +2774,14 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "
 "#;
         let result = link(&allocator, code, "test.mjs");
         assert!(result.linked);
-        // OnPush is the emit-time default, so the TS compiler leaves it out
-        // (`meta.changeDetection !== OnPush` in `compileComponentFromMetadata`);
-        // the runtime infers it from the absent field.
+        // Emitted explicitly, even though the TS compiler omits OnPush. That
+        // compiler ships with the runtime it targets; this linker does not know
+        // the consumer's version and supports back to v19, where the runtime
+        // computes `onPush = changeDetection === OnPush` and so reads an absent
+        // field as Default. Omitting it would silently drop OnPush there.
         assert!(
-            !result.code.contains("changeDetection"),
-            "ChangeDetectionStrategy.OnPush is the default and should not be emitted, got:\n{}",
+            result.code.contains("changeDetection: 0"),
+            "ChangeDetectionStrategy.OnPush should be 0, got:\n{}",
             result.code
         );
     }

--- a/crates/oxc_angular_compiler/src/linker/mod.rs
+++ b/crates/oxc_angular_compiler/src/linker/mod.rs
@@ -677,6 +677,24 @@ fn get_default_standalone_value(meta: &ObjectExpression<'_>) -> bool {
     true // If we can't determine the version, default to true (latest behavior)
 }
 
+/// Whether the declaration's `version` implies OnPush is the default change
+/// detection strategy. Angular v22 made OnPush the default; anything compiled
+/// against an earlier version meant `Eager`. The placeholder version used by dev
+/// builds tracks the newest behaviour.
+///
+/// Mirrors `hasOnPushByDefault` in the TS linker's `partial_component_linker_1.ts`.
+fn has_on_push_by_default(meta: &ObjectExpression<'_>) -> bool {
+    if let Some(version_str) = get_string_property(meta, "version") {
+        if version_str == "0.0.0-PLACEHOLDER" {
+            return true;
+        }
+        if let Ok(version) = semver::Version::parse(version_str) {
+            return version.major >= 22;
+        }
+    }
+    true // If we can't determine the version, default to true (latest behavior)
+}
+
 /// Extract the `deps` array from a factory metadata object and generate inject calls.
 ///
 /// The `target` parameter determines the inject function and flags:
@@ -2065,9 +2083,18 @@ fn link_component(
     if let Some(cd) = get_property_source(meta, "changeDetection", source) {
         if cd.contains("Eager") || cd.contains("Default") {
             parts.push("changeDetection: 1".to_string());
-        } else if cd.contains("OnPush") {
-            parts.push("changeDetection: 0".to_string());
         }
+        // OnPush is the emit-time default and is left out: the runtime derives
+        // `onPush = changeDetection !== Eager`, so an absent field already reads
+        // as OnPush. Matches the `meta.changeDetection !== OnPush` guard in
+        // `compileComponentFromMetadata`.
+    } else if !has_on_push_by_default(meta) {
+        // Omitted. Which strategy that meant depends on the version the library
+        // was compiled against, and the runtime reads an absent field as OnPush,
+        // so a pre-v22 declaration has to say Eager out loud. Without this a
+        // component silently switches from Eager to OnPush and stops re-rendering
+        // on anything that is not a signal or input change.
+        parts.push("changeDetection: 1".to_string());
     }
 
     let define_component =
@@ -2743,9 +2770,12 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "
 "#;
         let result = link(&allocator, code, "test.mjs");
         assert!(result.linked);
+        // OnPush is the emit-time default, so the TS compiler leaves it out
+        // (`meta.changeDetection !== OnPush` in `compileComponentFromMetadata`);
+        // the runtime infers it from the absent field.
         assert!(
-            result.code.contains("changeDetection: 0"),
-            "ChangeDetectionStrategy.OnPush should be 0, got:\n{}",
+            !result.code.contains("changeDetection"),
+            "ChangeDetectionStrategy.OnPush is the default and should not be emitted, got:\n{}",
             result.code
         );
     }
@@ -2766,6 +2796,73 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "
         assert!(
             result.code.contains("changeDetection: 1"),
             "ChangeDetectionStrategy.Eager should resolve to 1, got:\n{}",
+            result.code
+        );
+    }
+
+    // When a declaration omits `changeDetection`, the strategy it meant depends on
+    // the Angular version it was compiled with: v22 made OnPush the default, so
+    // anything older meant Eager. The TS linker resolves that with
+    // `hasOnPushByDefault = major >= 22 || version === PLACEHOLDER_VERSION`
+    // (partial_component_linker_1.ts). The runtime derives
+    // `onPush = changeDetection !== Eager`, so an omitted field reads as OnPush —
+    // which means a pre-v22 declaration has to emit `changeDetection: 1`
+    // explicitly, or the component silently switches strategy.
+
+    #[test]
+    fn test_link_component_pre_v22_without_change_detection_is_eager() {
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyComponent {
+}
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "21.2.14", ngImport: i0, type: MyComponent, selector: "my-comp", template: "<div></div>" });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            result.code.contains("changeDetection: 1"),
+            "A pre-v22 declaration without changeDetection means Eager, so it must be emitted explicitly, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_component_v22_without_change_detection_stays_on_push() {
+        // v22+ made OnPush the default, and the runtime already infers OnPush from
+        // an absent field, so nothing should be emitted.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyComponent {
+}
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "22.0.7", ngImport: i0, type: MyComponent, selector: "my-comp", template: "<div></div>" });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            !result.code.contains("changeDetection"),
+            "v22+ defaults to OnPush, which the runtime infers from an absent field, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_link_component_placeholder_version_without_change_detection_stays_on_push() {
+        // `0.0.0-PLACEHOLDER` is what Angular's own dev builds ship; the TS linker
+        // treats it as the newest behaviour.
+        let allocator = Allocator::default();
+        let code = r#"
+import * as i0 from "@angular/core";
+class MyComponent {
+}
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, selector: "my-comp", template: "<div></div>" });
+"#;
+        let result = link(&allocator, code, "test.mjs");
+        assert!(result.linked);
+        assert!(
+            !result.code.contains("changeDetection"),
+            "The placeholder version tracks the newest behaviour (OnPush), got:\n{}",
             result.code
         );
     }


### PR DESCRIPTION
## Summary

The linker emitted `changeDetection` only when the partial declaration carried the field, with no default for the omitted case.

Which strategy an omitted field means depends on the version the library was compiled against. Angular v22 made OnPush the default, so anything older meant `Eager`. The TS linker resolves that explicitly:

```ts
// partial_component_linker_1.ts
const hasOnPushByDefault = major >= 22 || version === PLACEHOLDER_VERSION;
...
changeDetection: metaObj.has('changeDetection')
  ? parseChangeDetectionStrategy(metaObj.getValue('changeDetection'))
  : hasOnPushByDefault ? ChangeDetectionStrategy.OnPush : ChangeDetectionStrategy.Eager,
```

## Impact

In v22 `OnPush = 0`, `Eager = 1`, and `Default = 1` is a deprecated alias for `Eager`. The runtime derives the flag from:

```ts
// packages/core/src/render3/definition.ts
onPush: componentDefinition.changeDetection !== ChangeDetectionStrategy.Eager,
```

So an **absent** field evaluates `undefined !== 1` and reads as **OnPush**. A pre-v22 component that never declared a strategy was therefore silently switched from Eager to OnPush, and stops re-rendering on anything that is not a signal or input change. Nothing is logged, so it surfaces only as stale UI.

Scanning a real `node_modules`: 154 `ɵɵngDeclareComponent` declarations, 139 of them pre-v22, and 6 of those omit the field. Most libraries do declare a strategy, so the blast radius is narrow, but the ones that do not are unlucky:

| Component | Selector | Compiled with |
| --- | --- | --- |
| `AgGridAngular` | `ag-grid-angular` | v17.3.12 |
| `HighchartsChartComponent` | `highcharts-chart` | v16.2.12 |
| `MarkdownComponent` | `markdown` | v21.2.5 |
| `_MatDialogContainerBase` | (none) | v16.1.1 |
| `NgpTooltipTextContentComponent` | (none) | v21.2.14 |
| `DynamicViewComponent` | `dynamic-view` | v18.0.4 |

A grid or chart component quietly becoming OnPush is a rough one to track down.

## Also in this change (reverted after review)

This originally stopped emitting `changeDetection: 0` for an explicit OnPush, to match the `meta.changeDetection !== OnPush` guard in `compileComponentFromMetadata`. That was wrong and has been reverted in cdd3353.

That compiler ships with the runtime it targets. This linker does not know the consumer's version: `angularLinkerPlugin()` takes no options and `linkCode` calls `linkAngularPackage(code, id)`, while the plugin's `angularVersion` option documents support back to v19. Angular 20 and 21 compute `onPush = changeDetection === OnPush`, so an absent field reads as Default there and the component would have silently lost OnPush. Emitting `0` is correct on both: pre-v22 `0 === 0`, v22 `0 !== 1`.

So this PR is now just the version-gated default. `1` is likewise correct on both runtimes (pre-v22 `1 === 0` is false, v22 `1 !== 1` is false, both Eager/Default).

One existing test asserted the `changeDetection: 0` emit; it is unchanged, and now carries a comment explaining why the emit has to stay so a future parity cleanup trips over it.

## Tests

Three tests covering the version gate: pre-v22 without the field must emit `changeDetection: 1`, v22+ must not emit, and `0.0.0-PLACEHOLDER` must not emit. Only the first is red before the fix; the other two are guards for behaviour that must not change.

The version gate reuses the shape of the existing `get_default_standalone_value` helper, which already does the same semver-plus-placeholder resolution for `standalone`.

## Verification

Every CI step run locally on macOS:

| Step | Result |
| --- | --- |
| `cargo check --all-features` | pass |
| `cargo test` | pass |
| `cargo fmt --all -- --check` | pass |
| `cargo run -p oxc_angular_conformance` | 1264/1264 (100%), snapshot byte-identical |
| `pnpm build-dev` + `build:ts` | pass |
| `pnpm test` | 200/200 |
| `pnpm check` | pass |
| `pnpm test:e2e` | 34/34 |
| `compare --fixtures` | 100% |

Also rebuilt the napi binding and confirmed `ag-grid-angular`, `highcharts-angular` and `ng-primitives` now emit `changeDetection: 1`.

Re-ran the full suite after the revert; all of the above still pass.

## Note

This was found by diffing linked output against `@angular/compiler-cli`'s linker rather than by any existing test, and the same exercise found #428. `compare --fixtures` stays at 100% throughout, because that harness covers source to AOT compilation and has no `ngDeclare` fixtures, so the linker currently has no differential coverage against the official linker. A partial-declaration category there would likely have caught both, but that is well outside the scope of this change.
