### PR TITLE
ci: publish to pkg.pr.new on push to main

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,25 +1,32 @@
 name: Publish to pkg.pr.new
 
-# Publishes a continuous preview release to https://pkg.pr.new whenever a
-# maintainer adds the `pkg.pr.new` label to a pull request (or via manual
-# dispatch). Requires the pkg.pr.new GitHub App to be installed on the repo:
+# Publishes a continuous preview release to https://pkg.pr.new on:
+# - every push to `main` (canary install of the latest main commit)
+# - when a maintainer adds the `pkg.pr.new` label to a pull request
+# - manual workflow_dispatch
+#
+# Requires the pkg.pr.new GitHub App to be installed on the repo:
 # https://github.com/apps/pkg-pr-new
 
 # One-shot per label by design (matches rolldown's PR preview): a preview is
 # built only when the `pkg.pr.new` label itself is added (the job guards check
 # the triggering label, github.event.label.name, NOT the full label set, so
 # adding any other label to an already-labeled PR does not rebuild).
-# `synchronize` is intentionally NOT subscribed, so later commits do not
+# `synchronize` is intentionally NOT subscribed, so later PR commits do not
 # rebuild — re-apply the label or use workflow_dispatch to refresh. This avoids
-# an 8-platform native build on every push.
+# an 8-platform native build on every PR push. Main-branch pushes always build.
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request:
     types: [labeled]
 
 permissions: {}
 
-# Cancel an in-flight preview when the label is re-applied on the same PR.
+# Cancel an in-flight preview when the label is re-applied on the same PR,
+# or when a newer main push supersedes a previous main publish.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -33,6 +40,7 @@ jobs:
     if: >
       github.repository == 'voidzero-dev/oxc-angular-compiler' &&
       (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'pkg.pr.new'))
     permissions:
       contents: read
@@ -43,6 +51,7 @@ jobs:
     if: >
       github.repository == 'voidzero-dev/oxc-angular-compiler' &&
       (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'pkg.pr.new'))
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -2,8 +2,8 @@ name: Reusable Build
 
 # Builds the native NAPI bindings for every target and uploads them as
 # `bindings-<target>` artifacts. Called by both `release.yml` (tag releases)
-# and `pkg.pr.new.yml` (PR preview packages) so the build matrix lives in one
-# place.
+# and `pkg.pr.new.yml` (main canary + PR preview packages) so the build matrix
+# lives in one place.
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary
- Trigger the existing `pkg.pr.new` workflow on every push to `main`, in addition to the `pkg.pr.new` PR label and `workflow_dispatch`.
- Keep the one-shot PR-label behavior (no rebuild on every PR commit); main always rebuilds.
- Update concurrency comments so a newer main push cancels an in-flight main publish.

## Test plan
- [ ] After merge, push (or wait for the merge commit) on `main` and confirm the **Publish to pkg.pr.new** workflow runs.
- [ ] Confirm the publish job succeeds and the package is available at the pkg.pr.new main URL.
- [ ] Confirm labeled-PR preview still works when the `pkg.pr.new` label is added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; increases CI load on `main` but does not touch application or release auth logic.
> 
> **Overview**
> Extends the **Publish to pkg.pr.new** workflow so every push to `main` runs the same 8-platform build and pkg.pr.new publish as labeled PR previews and manual dispatch, giving a continuous **main canary** install URL.
> 
> **Build** and **Publish preview** job `if` conditions now include `github.event_name == 'push'`; PR behavior is unchanged (still only when the `pkg.pr.new` label is added, not on every PR commit). Comments document main always rebuilding and clarify concurrency so a newer `main` push cancels an in-flight main publish. `reusable-build.yml` comment only notes main canary usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c0379e5c0cb29842ba18eb81f1c4378bc40d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->