### PR TITLE
0.0.36

### DIFF
--- a/napi/angular-compiler/index.js
+++ b/napi/angular-compiler/index.js
@@ -83,12 +83,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-android-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -106,12 +106,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-android-arm-eabi/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -141,12 +141,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-win32-x64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -164,12 +164,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-win32-x64-msvc/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -188,12 +188,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-win32-ia32-msvc/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -211,12 +211,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-win32-arm64-msvc/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -237,12 +237,12 @@ function requireNative() {
       const bindingPackageVersion =
         require('@oxc-angular/binding-darwin-universal/package.json').version
       if (
-        bindingPackageVersion !== '0.0.35' &&
+        bindingPackageVersion !== '0.0.36' &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+          `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
         )
       }
       return binding
@@ -260,12 +260,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-darwin-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -283,12 +283,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-darwin-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -310,12 +310,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-freebsd-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -333,12 +333,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-freebsd-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -361,12 +361,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-x64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -384,12 +384,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-x64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -409,12 +409,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -432,12 +432,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -457,12 +457,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm-musleabihf/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -480,12 +480,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm-gnueabihf/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -505,12 +505,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-loong64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -528,12 +528,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-loong64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -553,12 +553,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-riscv64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -576,12 +576,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-riscv64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.35' &&
+            bindingPackageVersion !== '0.0.36' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -600,12 +600,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-linux-ppc64-gnu/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -623,12 +623,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-linux-s390x-gnu/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -650,12 +650,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -673,12 +673,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -696,12 +696,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-arm/package.json').version
         if (
-          bindingPackageVersion !== '0.0.35' &&
+          bindingPackageVersion !== '0.0.36' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -844,9 +844,9 @@ if (!nativeBinding || forceWasi) {
         ) {
           const bindingPackageVersion =
             require('@oxc-angular/binding-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '0.0.35') {
+          if (bindingPackageVersion !== '0.0.36') {
             throw new Error(
-              `WASI binding package version mismatch, expected 0.0.35 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `WASI binding package version mismatch, expected 0.0.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
         }

--- a/napi/angular-compiler/package.json
+++ b/napi/angular-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-angular/vite",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Oxc Angular Compiler Vite plugin",
   "keywords": [
     "angular",


### PR DESCRIPTION
## Summary
- bump @oxc-angular/vite to 0.0.36
- update generated native binding version checks to 0.0.36

## Validation
- pnpm --filter ./napi/angular-compiler build:ts
- pnpm --filter ./napi/angular-compiler test
- cargo check --all-features
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 02d34ca57e971544b670ae412e2609e84babcedf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->