### PR TITLE
fix(ci): support Rust 1.98 aarch64 musl builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          tool: cargo-zigbuild
+          tool: cargo-zigbuild@0.23.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0


### PR DESCRIPTION
## Summary
- pin cargo-zigbuild to 0.23.0 in the reusable native build
- support Rust 1.98 aarch64 musl builds after the new --fix-cortex-a53-843419 linker argument

## Context
- v0.0.36 release run failed on aarch64-unknown-linux-musl: https://github.com/voidzero-dev/oxc-angular-compiler/actions/runs/32500561989
- upstream fix: https://github.com/rust-cross/cargo-zigbuild/issues/451

## Validation
- actionlint -shellcheck= .github/workflows/reusable-build.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pin of a build tool; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Pins `cargo-zigbuild` to **0.23.0** in the reusable native build workflow so musl targets (especially `aarch64-unknown-linux-musl`) work with Rust 1.98’s new `--fix-cortex-a53-843419` linker flag.
> 
> This unblocks failed release/canary native builds that previously installed an unpinned, older zigbuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd50ccc65378c51814d4f336cafdeb808f96ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->