### PR TITLE
fix(vite): stop requesting a full reload on component template HMR

### DIFF
--- a/napi/angular-compiler/README.md
+++ b/napi/angular-compiler/README.md
@@ -144,6 +144,17 @@ into one of these branches, mirroring Angular CLI's official behavior
 Set `liveReload: false` to disable both HMR and reloads — the plugin
 returns from `handleHotUpdate` without sending any event.
 
+"No reload" means no reload is requested. Vite full-reloads any changed
+`.html` whose module list is empty or holds no `js` module, so the plugin
+registers each component template in the module graph (`addWatchFile`) and
+returns it as its own HMR boundary. Without that, Vite puts a `full-reload`
+on the socket on top of every template edit. Its client usually drops that
+payload because the path does not match `location.pathname` — but in
+`middlewareMode` the path is `*`, which always reloads
+([#443](https://github.com/voidzero-dev/oxc-angular-compiler/issues/443)).
+
+`index.html` is not a component template, so it still triggers a full reload.
+
 ### Transform Options
 
 ```typescript

--- a/napi/angular-compiler/e2e/fixtures/test-fixture.ts
+++ b/napi/angular-compiler/e2e/fixtures/test-fixture.ts
@@ -142,6 +142,69 @@ export class HmrDetector {
   }
 
   /**
+   * Record every HMR websocket payload the dev server sends.
+   *
+   * Must be called BEFORE `page.goto`, because it wraps `window.WebSocket`
+   * and Vite's client opens its socket during page load.
+   *
+   * Reading the wire is the only honest way to assert that no reload was
+   * requested. Vite's client drops a `full-reload` whose `.html` path does
+   * not match `location.pathname`, so a DOM sentinel survives even when the
+   * server did ask for a reload.
+   */
+  async captureWirePayloads(): Promise<void> {
+    await this.page.addInitScript(() => {
+      const KEY = '__viteHmrPayloads'
+      const read = (): unknown[] => {
+        try {
+          return JSON.parse(sessionStorage.getItem(KEY) || '[]')
+        } catch {
+          return []
+        }
+      }
+      // Persist across navigations: a `full-reload` payload is only
+      // observable if the record outlives the reload it caused.
+      const record = (payload: unknown) => {
+        const all = read()
+        all.push(payload)
+        try {
+          sessionStorage.setItem(KEY, JSON.stringify(all))
+        } catch {
+          // Storage is unavailable; the assertion will report the gap.
+        }
+      }
+      const NativeWebSocket = window.WebSocket
+      class RecordingWebSocket extends NativeWebSocket {
+        constructor(url: string | URL, protocols?: string | string[]) {
+          super(url, protocols)
+          this.addEventListener('message', (event: MessageEvent) => {
+            try {
+              record(JSON.parse(event.data))
+            } catch {
+              // Non-JSON frames are not HMR payloads.
+            }
+          })
+        }
+      }
+      window.WebSocket = RecordingWebSocket as unknown as typeof WebSocket
+    })
+  }
+
+  /**
+   * Every HMR websocket payload recorded since `captureWirePayloads`,
+   * including payloads received before a reload.
+   */
+  async getWirePayloads(): Promise<Array<{ type: string; event?: string; path?: string }>> {
+    return await this.page.evaluate(() => {
+      try {
+        return JSON.parse(sessionStorage.getItem('__viteHmrPayloads') || '[]')
+      } catch {
+        return []
+      }
+    })
+  }
+
+  /**
    * Set up listeners to capture HMR events from the page.
    * Call this before making file changes.
    * Note: We use addScriptTag to inject the listener code because

--- a/napi/angular-compiler/e2e/tests/hmr-html.spec.ts
+++ b/napi/angular-compiler/e2e/tests/hmr-html.spec.ts
@@ -1,4 +1,24 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { test, expect } from '../fixtures/test-fixture.js'
+
+const INDEX_HTML = join(fileURLToPath(new URL('.', import.meta.url)), '../app/index.html')
+
+let indexHtmlBackup: string | undefined
+
+async function modifyIndexHtml(modifier: (content: string) => string): Promise<void> {
+  const content = await readFile(INDEX_HTML, 'utf-8')
+  indexHtmlBackup ??= content
+  await writeFile(INDEX_HTML, modifier(content))
+}
+
+async function restoreIndexHtml(): Promise<void> {
+  if (indexHtmlBackup === undefined) return
+  await writeFile(INDEX_HTML, indexHtmlBackup)
+  indexHtmlBackup = undefined
+}
 
 test.describe('HTML Template HMR', () => {
   test.beforeEach(async ({ page }) => {
@@ -79,5 +99,58 @@ test.describe('HTML Template HMR', () => {
 
     // Verify no reload - sentinel should survive
     expect(await hmrDetector.sentinelExists(sentinelId)).toBe(true)
+  })
+})
+
+test.describe('HTML Template HMR — no Vite full reload requested', () => {
+  // Regression test for https://github.com/voidzero-dev/oxc-angular-compiler/issues/443
+  //
+  // The DOM-sentinel tests above only prove the browser did not act on a
+  // reload. They pass even when the server puts a `full-reload` on the wire,
+  // because Vite's client drops an `.html` payload whose path does not match
+  // `location.pathname`. That guard is gone when the payload path is `*` —
+  // which is what Vite sends in `middlewareMode`, and what the reporter of
+  // #443 hit. So assert on the payload, not on its downstream effect.
+  test('modifying .html file sends no full-reload payload', async ({
+    page,
+    fileModifier,
+    hmrDetector,
+    waitForHmr,
+  }) => {
+    await hmrDetector.captureWirePayloads()
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await fileModifier.modifyFile('app.html', (content) =>
+      content.replace('{{ title() }}', 'NO_RELOAD_PAYLOAD'),
+    )
+    await waitForHmr()
+
+    await expect(page.locator('h1')).toContainText('NO_RELOAD_PAYLOAD')
+
+    const payloads = await hmrDetector.getWirePayloads()
+    expect(payloads.map((p) => p.event)).toContain('angular:component-update')
+    expect(payloads.map((p) => p.type)).not.toContain('full-reload')
+  })
+
+  test('modifying index.html still sends a full-reload payload', async ({
+    page,
+    hmrDetector,
+    waitForHmr,
+  }) => {
+    await hmrDetector.captureWirePayloads()
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await modifyIndexHtml((content) => content.replace('</body>', '  <!-- edited -->\n  </body>'))
+    try {
+      await waitForHmr()
+      const payloads = await hmrDetector.getWirePayloads()
+      expect(payloads.filter((p) => p.type === 'full-reload').map((p) => p.path)).toContain(
+        '/index.html',
+      )
+    } finally {
+      await restoreIndexHtml()
+    }
   })
 })

--- a/napi/angular-compiler/test/hmr-hot-update.test.ts
+++ b/napi/angular-compiler/test/hmr-hot-update.test.ts
@@ -101,6 +101,24 @@ function createMockServer() {
   }
 }
 
+/**
+ * Mock of Vite's mixed module node.
+ *
+ * `isSelfAccepting` is a prototype getter with no setter on the real node, so
+ * the plugin writes the flag to the client-environment node it delegates to.
+ * The returned `clientModule` is that node, so a test can assert on it.
+ */
+function createMockTemplateModule(id: string): {
+  module: Partial<ModuleNode>
+  clientModule: { isSelfAccepting: boolean }
+} {
+  const clientModule = { isSelfAccepting: false }
+  return {
+    module: { id, _clientModule: clientModule } as unknown as Partial<ModuleNode>,
+    clientModule,
+  }
+}
+
 function createMockHmrContext(
   file: string,
   modules: Partial<ModuleNode>[] = [],
@@ -630,8 +648,8 @@ describe('handleHotUpdate - Issue #185', () => {
     // `_clientModule` mirrors Vite's mixed module node: `isSelfAccepting` is
     // a prototype getter there, so the flag lands on the client node.
     const componentHtmlFile = normalizePath(templatePath)
-    const mockModules = [{ id: componentHtmlFile, _clientModule: { isSelfAccepting: false } }]
-    const ctx = createMockHmrContext(componentHtmlFile, mockModules, mockServer)
+    const { module: templateModule, clientModule } = createMockTemplateModule(componentHtmlFile)
+    const ctx = createMockHmrContext(componentHtmlFile, [templateModule], mockServer)
 
     const result = await callHandleHotUpdate(plugin, ctx)
 
@@ -640,8 +658,8 @@ describe('handleHotUpdate - Issue #185', () => {
     // `.html` on top of the update we just dispatched — and that reload is
     // unconditional in `middlewareMode`, where its path is `*`.
     // See https://github.com/voidzero-dev/oxc-angular-compiler/issues/443.
-    expect(result).toEqual(mockModules)
-    expect(mockModules[0]._clientModule.isSelfAccepting).toBe(true)
+    expect(result).toEqual([templateModule])
+    expect(clientModule.isSelfAccepting).toBe(true)
     expect(mockServer._wsMessages).toContainEqual(
       expect.objectContaining({ type: 'custom', event: 'angular:component-update' }),
     )
@@ -653,13 +671,13 @@ describe('handleHotUpdate - Issue #185', () => {
 
     // index.html must keep reloading the page — it is not hot-swappable.
     const indexHtml = normalizePath(join(tempDir, 'index.html'))
-    const mockModules = [{ id: indexHtml, _clientModule: { isSelfAccepting: false } }]
-    const ctx = createMockHmrContext(indexHtml, mockModules)
+    const { module: indexModule, clientModule } = createMockTemplateModule(indexHtml)
+    const ctx = createMockHmrContext(indexHtml, [indexModule])
 
     const result = await callHandleHotUpdate(plugin, ctx)
 
-    expect(result).toEqual(mockModules)
-    expect(mockModules[0]._clientModule.isSelfAccepting).toBe(false)
+    expect(result).toEqual([indexModule])
+    expect(clientModule.isSelfAccepting).toBe(false)
   })
 
   it('should not swallow non-resource HTML files', async () => {

--- a/napi/angular-compiler/test/hmr-hot-update.test.ts
+++ b/napi/angular-compiler/test/hmr-hot-update.test.ts
@@ -108,13 +108,16 @@ function createMockServer() {
  * the plugin writes the flag to the client-environment node it delegates to.
  * The returned `clientModule` is that node, so a test can assert on it.
  */
-function createMockTemplateModule(id: string): {
+function createMockTemplateModule(
+  id: string,
+  file: string = id,
+): {
   module: Partial<ModuleNode>
   clientModule: { isSelfAccepting: boolean }
 } {
   const clientModule = { isSelfAccepting: false }
   return {
-    module: { id, _clientModule: clientModule } as unknown as Partial<ModuleNode>,
+    module: { id, file, _clientModule: clientModule } as unknown as Partial<ModuleNode>,
     clientModule,
   }
 }
@@ -663,6 +666,29 @@ describe('handleHotUpdate - Issue #185', () => {
     expect(mockServer._wsMessages).toContainEqual(
       expect.objectContaining({ type: 'custom', event: 'angular:component-update' }),
     )
+  })
+
+  it('should not mark a postfixed variant of the template as self-accepting', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+    await transformComponent(plugin)
+
+    // Vite sets `file` to `cleanUrl(id)`, so a browser-imported
+    // `./app.component.html?raw` is filed under the template's path and shows
+    // up in `ctx.modules` alongside the node `addWatchFile` created.
+    const componentHtmlFile = normalizePath(templatePath)
+    const bare = createMockTemplateModule(componentHtmlFile)
+    const raw = createMockTemplateModule(`${componentHtmlFile}?raw`, componentHtmlFile)
+    const ctx = createMockHmrContext(componentHtmlFile, [bare.module, raw.module], mockServer)
+
+    await callHandleHotUpdate(plugin, ctx)
+
+    // Only the template itself becomes the boundary.
+    expect(bare.clientModule.isSelfAccepting).toBe(true)
+    // The `?raw` variant has real importers holding its value. Stopping
+    // propagation there would leave them with a stale string, because the
+    // browser has no `import.meta.hot.accept` handler for it.
+    expect(raw.clientModule.isSelfAccepting).toBe(false)
   })
 
   it('should not mark non-component HTML as self-accepting', async () => {

--- a/napi/angular-compiler/test/hmr-hot-update.test.ts
+++ b/napi/angular-compiler/test/hmr-hot-update.test.ts
@@ -189,7 +189,7 @@ async function transformComponent(plugin: Plugin) {
   }
 
   await plugin.transform.handler.call(
-    { error() {}, warn() {} } as any,
+    { error() {}, warn() {}, addWatchFile() {} } as any,
     COMPONENT_SOURCE,
     componentPath,
   )
@@ -286,7 +286,7 @@ describe('pendingHmrUpdates race condition', () => {
       throw new Error('Expected plugin transform handler')
     }
     await plugin.transform.handler.call(
-      { error() {}, warn() {} } as any,
+      { error() {}, warn() {}, addWatchFile() {} } as any,
       originalSource,
       multiComponentPath,
     )
@@ -332,7 +332,7 @@ describe('pendingHmrUpdates race condition', () => {
       throw new Error('Expected plugin transform handler')
     }
     await plugin.transform.handler.call(
-      { error() {}, warn() {} } as any,
+      { error() {}, warn() {}, addWatchFile() {} } as any,
       source,
       multiComponentPath,
     )
@@ -373,7 +373,11 @@ describe('pendingHmrUpdates race condition', () => {
     if (!plugin.transform || typeof plugin.transform === 'function') {
       throw new Error('Expected plugin transform handler')
     }
-    await plugin.transform.handler.call({ error() {}, warn() {} } as any, source, multiStylesPath)
+    await plugin.transform.handler.call(
+      { error() {}, warn() {}, addWatchFile() {} } as any,
+      source,
+      multiStylesPath,
+    )
 
     // Edit only YComponent's styles. Stripping wipes BOTH components' styles
     // (and templates), so old and new stripped forms must still match.
@@ -416,7 +420,11 @@ describe('pendingHmrUpdates race condition', () => {
     if (!plugin.transform || typeof plugin.transform === 'function') {
       throw new Error('Expected plugin transform handler')
     }
-    await plugin.transform.handler.call({ error() {}, warn() {} } as any, source, multiUrlPath)
+    await plugin.transform.handler.call(
+      { error() {}, warn() {}, addWatchFile() {} } as any,
+      source,
+      multiUrlPath,
+    )
 
     // Edit just first.component.html. resourceToComponent maps it to
     // multi-url.component.ts; dispatchAllComponentsInFile must fan out to
@@ -454,7 +462,11 @@ describe('pendingHmrUpdates race condition', () => {
     if (!plugin.transform || typeof plugin.transform === 'function') {
       throw new Error('Expected plugin transform handler')
     }
-    await plugin.transform.handler.call({ error() {}, warn() {} } as any, originalSource, stalePath)
+    await plugin.transform.handler.call(
+      { error() {}, warn() {}, addWatchFile() {} } as any,
+      originalSource,
+      stalePath,
+    )
 
     // Trigger an HMR-eligible edit so a pending entry is queued for both
     // components (including DropComponent).
@@ -471,7 +483,11 @@ describe('pendingHmrUpdates race condition', () => {
       export class KeepComponent {}
     `
     writeFileSync(stalePath, reducedSource)
-    await plugin.transform.handler.call({ error() {}, warn() {} } as any, reducedSource, stalePath)
+    await plugin.transform.handler.call(
+      { error() {}, warn() {}, addWatchFile() {} } as any,
+      reducedSource,
+      stalePath,
+    )
 
     const middleware = (mockServer.middlewares.use as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
 
@@ -501,7 +517,11 @@ describe('pendingHmrUpdates race condition', () => {
     if (!plugin.transform || typeof plugin.transform === 'function') {
       throw new Error('Expected plugin transform handler')
     }
-    await plugin.transform.handler.call({ error() {}, warn() {} } as any, source, multiReloadPath)
+    await plugin.transform.handler.call(
+      { error() {}, warn() {}, addWatchFile() {} } as any,
+      source,
+      multiReloadPath,
+    )
 
     // Change a class member, NOT the template/styles. The stripped form will
     // differ from the cached one → full reload, no HMR.
@@ -606,19 +626,40 @@ describe('handleHotUpdate - Issue #185', () => {
     const mockServer = await setupPluginWithServer(plugin)
     await transformComponent(plugin)
 
-    // The component's HTML template IS in resourceToComponent
+    // The component's HTML template IS in resourceToComponent.
+    // `_clientModule` mirrors Vite's mixed module node: `isSelfAccepting` is
+    // a prototype getter there, so the flag lands on the client node.
     const componentHtmlFile = normalizePath(templatePath)
-    const mockModules = [{ id: componentHtmlFile }]
+    const mockModules = [{ id: componentHtmlFile, _clientModule: { isSelfAccepting: false } }]
     const ctx = createMockHmrContext(componentHtmlFile, mockModules, mockServer)
 
     const result = await callHandleHotUpdate(plugin, ctx)
 
-    // Component HMR is dispatched, and Vite's modules are preserved for the
-    // default pipeline.
+    // Component HMR is dispatched, and the template module becomes its own
+    // HMR boundary. Without that, Vite sends a `full-reload` for the changed
+    // `.html` on top of the update we just dispatched — and that reload is
+    // unconditional in `middlewareMode`, where its path is `*`.
+    // See https://github.com/voidzero-dev/oxc-angular-compiler/issues/443.
     expect(result).toEqual(mockModules)
+    expect(mockModules[0]._clientModule.isSelfAccepting).toBe(true)
     expect(mockServer._wsMessages).toContainEqual(
       expect.objectContaining({ type: 'custom', event: 'angular:component-update' }),
     )
+  })
+
+  it('should not mark non-component HTML as self-accepting', async () => {
+    const plugin = getAngularPlugin()
+    await setupPluginWithServer(plugin)
+
+    // index.html must keep reloading the page — it is not hot-swappable.
+    const indexHtml = normalizePath(join(tempDir, 'index.html'))
+    const mockModules = [{ id: indexHtml, _clientModule: { isSelfAccepting: false } }]
+    const ctx = createMockHmrContext(indexHtml, mockModules)
+
+    const result = await callHandleHotUpdate(plugin, ctx)
+
+    expect(result).toEqual(mockModules)
+    expect(mockModules[0]._clientModule.isSelfAccepting).toBe(false)
   })
 
   it('should not swallow non-resource HTML files', async () => {

--- a/napi/angular-compiler/test/hmr-hot-update.test.ts
+++ b/napi/angular-compiler/test/hmr-hot-update.test.ts
@@ -56,10 +56,8 @@ afterAll(() => {
   rmSync(tempDir, { recursive: true, force: true })
 })
 
-function getAngularPlugin() {
-  const plugin = angular({ liveReload: true }).find(
-    (candidate) => candidate.name === '@oxc-angular/vite',
-  )
+function getAngularPlugin(options: Parameters<typeof angular>[0] = { liveReload: true }) {
+  const plugin = angular(options).find((candidate) => candidate.name === '@oxc-angular/vite')
 
   if (!plugin) {
     throw new Error('Failed to find @oxc-angular/vite plugin')
@@ -209,11 +207,19 @@ async function transformComponent(plugin: Plugin) {
     throw new Error('Expected plugin transform handler')
   }
 
+  const watched: string[] = []
   await plugin.transform.handler.call(
-    { error() {}, warn() {}, addWatchFile() {} } as any,
+    {
+      error() {},
+      warn() {},
+      addWatchFile(id: string) {
+        watched.push(normalizePath(id))
+      },
+    } as any,
     COMPONENT_SOURCE,
     componentPath,
   )
+  return watched
 }
 
 /**
@@ -761,9 +767,7 @@ describe('handleHotUpdate - Issue #185', () => {
   })
 
   it('should not act when liveReload is disabled', async () => {
-    const plugin = angular({ liveReload: false }).find(
-      (candidate) => candidate.name === '@oxc-angular/vite',
-    )!
+    const plugin = getAngularPlugin({ liveReload: false })
     const mockServer = await setupPluginWithServer(plugin)
 
     const utilFile = normalizePath(join(tempDir, 'src', 'utils.ts'))
@@ -773,5 +777,27 @@ describe('handleHotUpdate - Issue #185', () => {
 
     // No HMR or full-reload should be sent when liveReload is off.
     expect(mockServer._wsMessages).toHaveLength(0)
+  })
+
+  it('should not add template graph edges when liveReload is disabled', async () => {
+    const plugin = getAngularPlugin({ liveReload: false })
+    await setupPluginWithServer(plugin)
+
+    const watched = await transformComponent(plugin)
+
+    // The graph edge exists only to keep Vite off its `.html` reload branch
+    // during HMR. With HMR off, `handleHotUpdate` returns before it can use
+    // the edge, and the edge alone turns Vite's dropped `.html` payload into
+    // an unconditional `full-reload` with path `*`.
+    expect(watched).toEqual([])
+  })
+
+  it('should add a template graph edge when liveReload is enabled', async () => {
+    const plugin = getAngularPlugin()
+    await setupPluginWithServer(plugin)
+
+    const watched = await transformComponent(plugin)
+
+    expect(watched).toContain(normalizePath(templatePath))
   })
 })

--- a/napi/angular-compiler/test/style-deps-hmr.test.ts
+++ b/napi/angular-compiler/test/style-deps-hmr.test.ts
@@ -156,7 +156,11 @@ async function transformComponent(plugin: Plugin, source: string, path: string) 
     throw new Error('Expected plugin transform handler')
   }
 
-  await plugin.transform.handler.call({ error() {}, warn() {} } as any, source, path)
+  await plugin.transform.handler.call(
+    { error() {}, warn() {}, addWatchFile() {} } as any,
+    source,
+    path,
+  )
 }
 
 function componentUpdateCount(server: any): number {

--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -14,7 +14,7 @@ import { ServerResponse } from 'node:http'
 import { dirname, resolve } from 'node:path'
 
 import { createDebug } from 'obug'
-import type { Plugin, ResolvedConfig, ViteDevServer, Connect } from 'vite'
+import type { Plugin, ResolvedConfig, ViteDevServer, Connect, ModuleNode } from 'vite'
 import { preprocessCSS, normalizePath } from 'vite'
 
 // Debug loggers - enable with DEBUG=vite:oxc-angular:*
@@ -151,7 +151,32 @@ export interface PluginOptions {
 
 // Match all TypeScript files - we'll filter by @Component/@Directive decorator in the handler
 const ANGULAR_TS_REGEX = /\.tsx?$/
+const TEMPLATE_REGEX = /\.html?$/
 const ANGULAR_COMPONENT_PREFIX = '@ng/component'
+
+/** True when `mod` is the module graph node for `normalizedFile`. */
+function isModuleForFile(mod: ModuleNode, normalizedFile: string): boolean {
+  const file = mod.file ?? mod.id
+  return !!file && normalizePath(file) === normalizedFile
+}
+
+/**
+ * Make `mod` its own HMR boundary, so an update stops there instead of
+ * propagating to the modules that import it.
+ *
+ * On the deprecated mixed module node, `isSelfAccepting` is a prototype
+ * getter with no setter. The flag therefore goes on the client-environment
+ * node it delegates to, which is both writable and the node Vite reads when
+ * it propagates the update. The node is mutated in place: a spread copy
+ * would drop every prototype getter, including the `id` Vite matches on.
+ */
+function markModuleSelfAccepting(mod: ModuleNode): void {
+  const clientModule = (mod as { _clientModule?: { isSelfAccepting?: boolean } })._clientModule
+  if (clientModule) {
+    clientModule.isSelfAccepting = true
+  }
+}
+
 type InlineBuildMinifyOptions = {
   cssMinify?: boolean | string
   minify?: boolean | string
@@ -753,13 +778,18 @@ export function angular(options: PluginOptions = {}): Plugin[] {
           const isSSR = !!options?.ssr
 
           // Track dependencies for resource cache invalidation and HMR.
-          // We don't call addWatchFile (which would create modules in Vite's
-          // graph) or maintain a custom watcher — Vite's chokidar sees the
-          // root tree via its normal HMR pipeline, and our `handleHotUpdate`
-          // hook below dispatches based on `resourceToComponent` membership.
-          // Preprocessor deps can resolve outside the root (shared monorepo
-          // packages, configured include paths), so those are registered with
-          // the watcher explicitly below.
+          // `handleHotUpdate` below dispatches based on `resourceToComponent`
+          // membership. Preprocessor deps can resolve outside the root
+          // (shared monorepo packages, configured include paths), so they are
+          // registered with the watcher explicitly below.
+          //
+          // `addWatchFile` does more than watch: `vite:import-analysis` folds
+          // plugin-added imports into the module graph, so each resource
+          // becomes a real module with this component `.ts` as its importer.
+          // That is load-bearing for templates. Vite full-reloads a changed
+          // `.html` whose module list is empty or holds no `js` module, and a
+          // template we hot-swap ourselves must not be in either state. See
+          // `handleHotUpdate` and https://github.com/voidzero-dev/oxc-angular-compiler/issues/443.
           if (watchMode && viteServer) {
             // Prune stale reverse mappings: if this component previously
             // referenced different resources (e.g., templateUrl was renamed),
@@ -791,6 +821,15 @@ export function angular(options: PluginOptions = {}): Plugin[] {
               // Watch the file so edits reach `handleHotUpdate` even when it
               // lives outside the dev-server root.
               viteServer.watcher?.add?.(dep)
+              // Templates only. Styles must stay out of the graph: the
+              // import edge makes Vite propagate a style change up to this
+              // component `.ts` and re-execute it, which defines a duplicate
+              // class and leaves `angular:component-update` patching a class
+              // that is no longer mounted. Styles never needed it — Vite only
+              // force-reloads on `.html`.
+              if (TEMPLATE_REGEX.test(normalizedDep)) {
+                this.addWatchFile(dep)
+              }
             }
           }
 
@@ -1022,6 +1061,30 @@ export function angular(options: PluginOptions = {}): Plugin[] {
           // stylesheet that imports the same partial — must keep flowing
           // through Vite's default pipeline; returning [] would drop them and
           // leave that CSS stale.
+          //
+          // A template we just hot-swapped is the one exception. Vite sends a
+          // `full-reload` for any changed `.html` whose module list is empty
+          // or holds no `js` module. Its client normally drops that payload
+          // because the path does not match `location.pathname` — but in
+          // `middlewareMode` the path is `*`, which always reloads. So the
+          // update is applied and the page reloads on top of it (issue #443).
+          //
+          // `addWatchFile` in `transform` already put the template in the
+          // graph as a `js` module, which clears that branch. Marking it
+          // self-accepting makes it its own HMR boundary, so the update stops
+          // there instead of propagating up and re-executing the component
+          // `.ts` — a second evaluation would define a duplicate class
+          // (NG0912) and leave `angular:component-update` patching a class
+          // that is no longer mounted.
+          //
+          // The browser never imported the template, so Vite's client finds
+          // no `hotModulesMap` entry and the update is a no-op there. The DOM
+          // change comes entirely from `angular:component-update` above.
+          if (handled && TEMPLATE_REGEX.test(normalizedFile)) {
+            for (const mod of ctx.modules) {
+              if (isModuleForFile(mod, normalizedFile)) markModuleSelfAccepting(mod)
+            }
+          }
           return ctx.modules
         }
 

--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -154,10 +154,17 @@ const ANGULAR_TS_REGEX = /\.tsx?$/
 const TEMPLATE_REGEX = /\.html?$/
 const ANGULAR_COMPONENT_PREFIX = '@ng/component'
 
-/** True when `mod` is the module graph node for `normalizedFile`. */
+/**
+ * True when `mod` is the module graph node for `normalizedFile` itself, and
+ * not a postfixed variant of it.
+ *
+ * Vite sets `mod.file` to `cleanUrl(mod.id)`, which strips `?` and `#`, so a
+ * template that application code also imports as `./tpl.html?raw` is filed
+ * under the same `file` and appears in `ctx.modules` too. Matching on `id`
+ * keeps the two apart: an exact match means same file, no postfix.
+ */
 function isModuleForFile(mod: ModuleNode, normalizedFile: string): boolean {
-  const file = mod.file ?? mod.id
-  return !!file && normalizePath(file) === normalizedFile
+  return !!mod.id && normalizePath(mod.id) === normalizedFile
 }
 
 /**
@@ -1080,6 +1087,11 @@ export function angular(options: PluginOptions = {}): Plugin[] {
           // The browser never imported the template, so Vite's client finds
           // no `hotModulesMap` entry and the update is a no-op there. The DOM
           // change comes entirely from `angular:component-update` above.
+          //
+          // Only the template's own node is marked. A variant the browser did
+          // import — `./tpl.html?raw` and friends — keeps propagating to its
+          // importers, which would otherwise hold a stale value: Vite would
+          // stop at a module with no `import.meta.hot.accept` handler.
           if (handled && TEMPLATE_REGEX.test(normalizedFile)) {
             for (const mod of ctx.modules) {
               if (isModuleForFile(mod, normalizedFile)) markModuleSelfAccepting(mod)

--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -828,13 +828,21 @@ export function angular(options: PluginOptions = {}): Plugin[] {
               // Watch the file so edits reach `handleHotUpdate` even when it
               // lives outside the dev-server root.
               viteServer.watcher?.add?.(dep)
-              // Templates only. Styles must stay out of the graph: the
-              // import edge makes Vite propagate a style change up to this
-              // component `.ts` and re-execute it, which defines a duplicate
-              // class and leaves `angular:component-update` patching a class
-              // that is no longer mounted. Styles never needed it — Vite only
-              // force-reloads on `.html`.
-              if (TEMPLATE_REGEX.test(normalizedDep)) {
+              // Templates only, and only while HMR is on.
+              //
+              // Styles must stay out of the graph: the import edge makes Vite
+              // propagate a style change up to this component `.ts` and
+              // re-execute it, which defines a duplicate class and leaves
+              // `angular:component-update` patching a class that is no longer
+              // mounted. Styles never needed it — Vite only force-reloads on
+              // `.html`.
+              //
+              // With `liveReload: false`, `handleHotUpdate` returns before it
+              // can use the edge, so the edge has no consumer other than
+              // Vite's default propagation — which is exactly what turns a
+              // payload the client would have dropped into an unconditional
+              // `full-reload` with path `*`.
+              if (pluginOptions.liveReload && TEMPLATE_REGEX.test(normalizedDep)) {
                 this.addWatchFile(dep)
               }
             }


### PR DESCRIPTION
Fixes #443.

## The bug

Editing a component `templateUrl` `.html` puts a `full-reload` on the HMR socket, on top of the `angular:component-update` that already hot-swapped the template.

```
edit  src/app/app.html
        │
        ▼
plugin handleHotUpdate
   ├─ ws.send  angular:component-update      ← the real HMR, works
   └─ return ctx.modules  ==  []             ← the template is watched, never a module
        │
        ▼
vite 8   updateModules
   if (!modules.length && file.endsWith('.html') && env === 'client')
        └─ hot.send({ type: 'full-reload', path: … })
```

Whether the browser obeys depends on the payload path. Vite's client only path-matches when the path ends in `.html`; a `*` path skips that test and reloads at once.

| setup | payload | reloads? |
|---|---|---|
| plain SPA at `/` | `/src/app/app.html` | no |
| deep route, or `base: '/app/'` | `/src/app/app.html` | no |
| **`server.middlewareMode: true`** | `"*"` | **yes** |
| **template also in the module graph** | `"*"` | **yes** |
| `.css` styleUrl edit | none sent | no |

Reproduced at the reporter's versions — `@oxc-angular/vite@0.0.35`, `vite@8.2.1`, `@angular/*@21.2.21`. Console order in the failing case:

```
[SPY] angular:component-update {…}          ← DOM updates
[SPY] vite:beforeFullReload {"path":"*"}    ← ~2 ms later
[vite] connecting...                        ← new document
```

Even where the browser ignores the payload, Vite prints `page reload src/app/app.html` and clears the terminal on every save.

## The fix

Register each template with `addWatchFile`, so it enters the module graph as a `js` module with the component `.ts` as its importer, and return it as its own HMR boundary. Both of Vite's `.html` reload branches are then unreachable.

The browser never imported the template, so Vite's client finds no `hotModulesMap` entry and the resulting `js-update` is a no-op there. The DOM change still comes entirely from `angular:component-update`. Verified: `moduleEvalCount: 0`, no console errors, and the browser never requests the `.html`.

**Templates only.** An import edge on a *style* makes Vite propagate the change up to the component `.ts` and re-execute it, which defines a duplicate class (NG0912) and leaves `angular:component-update` patching a class that is no longer mounted. Styles then go stale from the second edit onward — this showed up as three red e2e tests while developing. Styles never needed the edge: Vite only force-reloads on `.html`.

Two other candidates were measured and rejected, because both look correct on the first edit and serve a stale template from the second onward:

| candidate | fixes `middlewareMode`? | second edit |
|---|---|---|
| return `[]` | no — path is hardcoded `*` there | ok |
| `addWatchFile` alone | yes | **stale** |
| return the component `.ts` module | yes | **stale** |
| `addWatchFile` + self-accepting | **yes** | **ok** |

## Why no test caught it

The e2e sentinel tests assert the browser did not *act* on a reload. That stayed true while the server kept asking for one. `setupEventListeners` was meant to cover the gap, but an injected `<script type="module">` has no `import.meta.hot`, so it never registered a listener — and no test ever read its output.

Added `HmrDetector.captureWirePayloads`, which wraps `WebSocket` before page load and persists payloads in `sessionStorage` so a `full-reload` is still observable after the reload it caused. Two new tests:

- a template edit sends no `full-reload` payload (fails on `main` with `["connected","full-reload","custom","full-reload"]`)
- `index.html` still sends one — it is not hot-swappable and must keep reloading

## Verification

- 213 unit tests pass, 36 e2e tests pass, `oxfmt --check` clean.
- `middlewareMode` repro at the reporter's versions: `navs: 0`, sentinel survives, second edit renders `MARKER_V2_EDITED`, `moduleEvalCount: 0`.
- Regressions re-checked in `middlewareMode`: `index.html` still reloads, component `.css` still hot-swaps, a global stylesheet still flows through Vite's CSS pipeline (#185), plain `.ts` still full-reloads.

## Review round (Codex)

Four P2 findings, each verified empirically before acting. Two were real regressions from this PR and are fixed; two are declined with measurements.

| # | finding | verdict | action |
|---|---|---|---|
| 1 | shared `templateUrl` only updates one owner | pre-existing; stated mechanism refuted; this PR improves it | [#445](https://github.com/voidzero-dev/oxc-angular-compiler/issues/445) |
| 2 | `?raw` variant marked self-accepting | confirmed, introduced here | fixed in `b52bc85` |
| 3 | graph edge added when `liveReload: false` | confirmed, introduced here | fixed in `07ed3ec` |
| 4 | self-accept flag survives template pruning | confirmed but unobservable; suggested fix is a regression | declined |

On #4: clearing the flag does not restore Vite's droppable `.html` reload — the node is `type: 'js'`, so propagation dead-ends and Vite sends `path="*"`, an unconditional reload in both modes. That is the same regression class #3 just removed. Full measurements are in the review threads.

## Known limits

- A `templateUrl` shared by two components still hot-updates only one of them — pre-existing, tracked in #445.
- At `liveReload: false`, a reload serves the old template, because every `resourceCache.delete` sits inside `handleHotUpdate` past its early return. Pre-existing on `main`; a product call, not settled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUvBViRkyuDvqUMkuT5XnH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Vite HMR module-graph and self-accept behavior; a mistake can cause full reloads, stale templates, or duplicate component classes (NG0912). Scoped to templates with unit and e2e coverage.
> 
> **Overview**
> Stops Vite from putting a `full-reload` on the HMR socket when a component `templateUrl` `.html` is edited, which stacked on top of `angular:component-update` and always reloaded in `middlewareMode` (path `*`) — **#443**.
> 
> The plugin now `addWatchFile`s templates (HMR on only, never styles) so they exist as `js` modules in the graph, then marks the template’s own node self-accepting so the update does not re-execute the component `.ts`. `?raw` and other postfixed variants stay un-marked; `index.html` still full-reloads.
> 
> E2E now records HMR websocket payloads (not just DOM sentinels) and asserts a template edit sends no `full-reload` while `index.html` still does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ed3ec133cde7784a827af1bb5596dc7caa2140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
