### PR TITLE
fix(vite): dispatch HMR for both decorator roles of one resource

### DIFF
--- a/napi/angular-compiler/test/hmr-hot-update.test.ts
+++ b/napi/angular-compiler/test/hmr-hot-update.test.ts
@@ -1010,6 +1010,188 @@ describe('handleHotUpdate for a templateUrl shared across component files - Issu
   })
 })
 
+describe('handleHotUpdate for a resource used in two decorator roles - Issue #450', () => {
+  async function transformDualComponent(plugin: Plugin, source: string, path: string) {
+    if (!plugin.transform || typeof plugin.transform === 'function') {
+      throw new Error('Expected plugin transform handler')
+    }
+    await plugin.transform.handler.call(
+      { error() {}, warn() {}, addWatchFile() {} } as any,
+      source,
+      path,
+    )
+  }
+
+  function componentUpdateIds(server: any): string[] {
+    return server._wsMessages
+      .filter((m: any) => m.event === 'angular:component-update')
+      .map((m: any) => decodeURIComponent(m.data.id))
+  }
+
+  const styleOwnerSource = (selector: string, className: string, styleUrl: string) => `
+    import { Component } from '@angular/core';
+    @Component({ selector: '${selector}', template: '<p>inline</p>', styleUrls: ['./${styleUrl}'] })
+    export class ${className} {}
+  `
+
+  const templateOwnerSource = (selector: string, className: string, templateUrl: string) => `
+    import { Component } from '@angular/core';
+    @Component({ selector: '${selector}', templateUrl: './${templateUrl}' })
+    export class ${className} {}
+  `
+
+  /**
+   * One file, two decorator roles: component A's styleUrl and component B's
+   * templateUrl. Both owners must receive an update when it changes.
+   *
+   * The file holds template markup, not CSS: the template owner must compile,
+   * and a styleUrl is registered as a direct style regardless of whether
+   * preprocessing succeeds.
+   */
+  async function runDualRoleCase(
+    plugin: Plugin,
+    mockServer: any,
+    prefix: string,
+    transformTemplateOwnerFirst: boolean,
+  ) {
+    const dualPath = join(appDir, `${prefix}-dual.css`)
+    const stylePath = join(appDir, `${prefix}-style-owner.component.ts`)
+    const templatePath = join(appDir, `${prefix}-template-owner.component.ts`)
+    writeFileSync(dualPath, '<p>DUAL_V1</p>')
+
+    const styleSource = styleOwnerSource(
+      `app-${prefix}-style`,
+      'StyleOwnerComponent',
+      `${prefix}-dual.css`,
+    )
+    const templateSource = templateOwnerSource(
+      `app-${prefix}-template`,
+      'TemplateOwnerComponent',
+      `${prefix}-dual.css`,
+    )
+    writeFileSync(stylePath, styleSource)
+    writeFileSync(templatePath, templateSource)
+
+    if (transformTemplateOwnerFirst) {
+      await transformDualComponent(plugin, templateSource, templatePath)
+      await transformDualComponent(plugin, styleSource, stylePath)
+    } else {
+      await transformDualComponent(plugin, styleSource, stylePath)
+      await transformDualComponent(plugin, templateSource, templatePath)
+    }
+
+    writeFileSync(dualPath, '<p>DUAL_V2</p>')
+    await callHandleHotUpdate(
+      plugin,
+      createMockHmrContext(normalizePath(dualPath), [{ id: normalizePath(dualPath) }], mockServer),
+    )
+
+    return { stylePath, templatePath }
+  }
+
+  it('dispatches to the style owner and the template owner of the same file', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // Template owner first: this order leaves the style owner as the only
+    // member of styleComponentOwners, so forking on `isDirectStyle` skipped
+    // the template owner entirely and it kept rendering the old template.
+    const { stylePath, templatePath } = await runDualRoleCase(plugin, mockServer, 'dr', true)
+
+    const ids = componentUpdateIds(mockServer)
+    expect(ids).toContain(`${stylePath}@StyleOwnerComponent`)
+    expect(ids).toContain(`${templatePath}@TemplateOwnerComponent`)
+  })
+
+  it('dispatches to both owners regardless of transform order', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // Style owner first. The role sets are global and monotonic, so the
+    // second-transformed file registers in BOTH owner maps and the style loop
+    // alone happened to cover both. Pinned so the outcome stays order-independent.
+    const { stylePath, templatePath } = await runDualRoleCase(plugin, mockServer, 'dro', false)
+
+    const ids = componentUpdateIds(mockServer)
+    expect(ids).toContain(`${stylePath}@StyleOwnerComponent`)
+    expect(ids).toContain(`${templatePath}@TemplateOwnerComponent`)
+  })
+
+  it('dispatches exactly once per class when one file owns the resource in both roles', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // Both classes live in ONE .ts file, so that file is registered as both a
+    // style owner and a template owner. Dispatching per role would send two
+    // events per class.
+    const dualPath = join(appDir, 'same-file-dual.css')
+    const ownerPath = join(appDir, 'same-file-owner.component.ts')
+    writeFileSync(dualPath, '<p>SAME_FILE_V1</p>')
+
+    const source = `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-sf-style', template: '<p>inline</p>', styleUrls: ['./same-file-dual.css'] })
+      export class SameFileStyleComponent {}
+      @Component({ selector: 'app-sf-template', templateUrl: './same-file-dual.css' })
+      export class SameFileTemplateComponent {}
+    `
+    writeFileSync(ownerPath, source)
+    await transformDualComponent(plugin, source, ownerPath)
+
+    writeFileSync(dualPath, '<p>SAME_FILE_V2</p>')
+    await callHandleHotUpdate(
+      plugin,
+      createMockHmrContext(normalizePath(dualPath), [{ id: normalizePath(dualPath) }], mockServer),
+    )
+
+    const ids = componentUpdateIds(mockServer)
+    expect(ids).toContain(`${ownerPath}@SameFileStyleComponent`)
+    expect(ids).toContain(`${ownerPath}@SameFileTemplateComponent`)
+    expect(ids.filter((id) => id === `${ownerPath}@SameFileStyleComponent`)).toHaveLength(1)
+    expect(ids.filter((id) => id === `${ownerPath}@SameFileTemplateComponent`)).toHaveLength(1)
+  })
+
+  it('dispatches exactly once per component for a plain shared styleUrl', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // Guard: a style with no template role keeps its existing behavior — one
+    // event per owning component, no duplicates.
+    const sharedCssPath = join(appDir, 'plain-shared.component.css')
+    const firstPath = join(appDir, 'plain-first.component.ts')
+    const secondPath = join(appDir, 'plain-second.component.ts')
+    writeFileSync(sharedCssPath, 'h1 { color: red; }')
+
+    const firstSource = styleOwnerSource(
+      'app-plain-first',
+      'PlainFirstComponent',
+      'plain-shared.component.css',
+    )
+    const secondSource = styleOwnerSource(
+      'app-plain-second',
+      'PlainSecondComponent',
+      'plain-shared.component.css',
+    )
+    writeFileSync(firstPath, firstSource)
+    writeFileSync(secondPath, secondSource)
+    await transformDualComponent(plugin, firstSource, firstPath)
+    await transformDualComponent(plugin, secondSource, secondPath)
+
+    writeFileSync(sharedCssPath, 'h1 { color: blue; }')
+    await callHandleHotUpdate(
+      plugin,
+      createMockHmrContext(
+        normalizePath(sharedCssPath),
+        [{ id: normalizePath(sharedCssPath) }],
+        mockServer,
+      ),
+    )
+
+    const ids = componentUpdateIds(mockServer)
+    expect(ids).toEqual([`${firstPath}@PlainFirstComponent`, `${secondPath}@PlainSecondComponent`])
+  })
+})
+
 describe('@ng/component endpoint resolves the template per class', () => {
   async function transformSource(plugin: Plugin, source: string, path: string) {
     if (!plugin.transform || typeof plugin.transform === 'function') {

--- a/napi/angular-compiler/test/style-deps-hmr.test.ts
+++ b/napi/angular-compiler/test/style-deps-hmr.test.ts
@@ -198,6 +198,33 @@ describe('handleHotUpdate for transitive style dependencies', () => {
     expect(updatedIds.some((id) => id.startsWith(secondComponentPath))).toBe(true)
   })
 
+  it('dispatches exactly once per component for a transitive-only partial', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // Guard: `_shared.scss` is only ever a transitive dep, never a direct
+    // styleUrl. The shared-dep branch handles it; the direct-resource branch
+    // must not dispatch a second time for the same components.
+    await transformComponent(
+      plugin,
+      componentSource('app-first', 'first.component.scss'),
+      firstComponentPath,
+    )
+    await transformComponent(
+      plugin,
+      componentSource('app-second', 'second.component.scss'),
+      secondComponentPath,
+    )
+
+    await (plugin.handleHotUpdate as Function).call(
+      plugin,
+      createMockHmrContext(sharedScssPath, mockServer),
+    )
+
+    // Two owning components, one class each: exactly two events.
+    expect(componentUpdateCount(mockServer)).toBe(2)
+  })
+
   it('leaves untracked stylesheets to Vite', async () => {
     const plugin = getAngularPlugin()
     const mockServer = await setupPluginWithServer(plugin)

--- a/napi/angular-compiler/test/style-deps-hmr.test.ts
+++ b/napi/angular-compiler/test/style-deps-hmr.test.ts
@@ -582,3 +582,78 @@ describe('handleHotUpdate for transitive style dependencies', () => {
     expect(componentUpdateCount(mockServer)).toBe(1)
   })
 })
+
+describe('handleHotUpdate for a resource reached through both dispatch paths', () => {
+  it('dispatches once per class when a transitive dep is also a direct templateUrl', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // `_dual-role.scss` wears two hats at once:
+    //   - transitive dep: `dual-importer.component.scss` @uses it, so it
+    //     reaches components through the shared-dep branch.
+    //   - direct templateUrl: a component renders it directly, so it also
+    //     reaches components through the direct-resource branch.
+    // Its contents must parse as BOTH Sass and an Angular template, so a
+    // comment is the one body that satisfies both grammars (a CSS rule fails
+    // the template parser; bare text fails Sass).
+    const partialPath = join(appDir, '_dual-role.scss')
+    const importerPath = join(appDir, 'dual-importer.component.scss')
+    const bothRolesPath = join(appDir, 'dual-both.component.ts')
+    const transitiveOnlyPath = join(appDir, 'dual-transitive-only.component.ts')
+
+    writeFileSync(partialPath, '/* DUAL_ROLE_MARKER */')
+    writeFileSync(importerPath, "@use './dual-role';")
+
+    // One `.ts` owning BOTH paths: its style pulls the partial in
+    // transitively, and its sibling uses the same partial as a template.
+    const bothRolesSource = `
+      import { Component } from '@angular/core';
+
+      @Component({
+        selector: 'app-dual-style',
+        template: '<h1>Hello</h1>',
+        styleUrls: ['./dual-importer.component.scss'],
+      })
+      export class DualStyleComponent {}
+
+      @Component({
+        selector: 'app-dual-template',
+        templateUrl: './_dual-role.scss',
+      })
+      export class DualTemplateComponent {}
+    `
+    // A second owner reached ONLY through the shared-dep branch. Its update
+    // proves that branch really ran, so the assertions below are not just the
+    // template branch firing twice.
+    const transitiveOnlySource = componentSource(
+      'app-dual-transitive',
+      'dual-importer.component.scss',
+    )
+
+    writeFileSync(bothRolesPath, bothRolesSource)
+    writeFileSync(transitiveOnlyPath, transitiveOnlySource)
+
+    await transformComponent(plugin, bothRolesSource, bothRolesPath)
+    await transformComponent(plugin, transitiveOnlySource, transitiveOnlyPath)
+
+    writeFileSync(partialPath, '/* DUAL_ROLE_MARKER edited */')
+    await (plugin.handleHotUpdate as Function).call(
+      plugin,
+      createMockHmrContext(partialPath, mockServer),
+    )
+
+    const ids = mockServer._wsMessages
+      .filter((msg: any) => msg?.event === 'angular:component-update')
+      .map((msg: any) => decodeURIComponent(msg.data.id))
+    const countOf = (id: string) => ids.filter((candidate: string) => candidate === id).length
+
+    // The shared-dep branch ran: the transitive-only owner was updated.
+    expect(countOf(`${transitiveOnlyPath}@AppComponent`)).toBe(1)
+
+    // The dual-path owner is dispatched by the shared-dep branch and would be
+    // dispatched again by the direct-template loop. `ws.send` is not
+    // idempotent, so each class must still see exactly one event.
+    expect(countOf(`${bothRolesPath}@DualStyleComponent`)).toBe(1)
+    expect(countOf(`${bothRolesPath}@DualTemplateComponent`)).toBe(1)
+  })
+})

--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -1058,6 +1058,23 @@ export function angular(options: PluginOptions = {}): Plugin[] {
         // deps for all of them, and their partials must reach this branch.
         if (/\.(html?|css|scss|sass|less|styl|stylus|pcss|postcss|sss)$/.test(ctx.file)) {
           let handled = false
+          // Owner files already sent an update during this invocation. The
+          // `ws.send` in `dispatchComponentUpdate` is not idempotent, so an
+          // owner reachable through more than one path below would otherwise
+          // emit a second event for every class in it.
+          const dispatchedOwners = new Set<string>()
+          // Dispatch every component in one owner file. `skipIfDispatched` is
+          // set by the template loop alone: role-independent dispatch (#450)
+          // newly lets it run after the shared-dep branch, so it must not
+          // re-send. The style paths record but never skip — their overlap
+          // with the shared-dep branch predates #450 and is tracked in #453.
+          const dispatchOwner = (owner: string, skipIfDispatched = false): boolean => {
+            if (skipIfDispatched && dispatchedOwners.has(owner)) return false
+            dispatchedOwners.add(owner)
+            if (!dispatchAllComponentsInFile(owner)) return false
+            handled = true
+            return true
+          }
           // Shared preprocessor dependency (e.g. a Sass partial): rebuild every
           // style compiled from it and HMR each owning component.
           if (styleDepOwners.has(normalizedFile)) {
@@ -1074,9 +1091,8 @@ export function angular(options: PluginOptions = {}): Plugin[] {
               // A style shared by several components updates every one of
               // them (resourceToComponent is single-valued).
               for (const owner of styleComponentOwners.get(normalizePath(stylePath)) ?? []) {
-                if (dispatchAllComponentsInFile(owner)) {
+                if (dispatchOwner(owner)) {
                   debugHmr('style dep HMR: %s -> %s -> %s', normalizedFile, stylePath, owner)
-                  handled = true
                 }
               }
             }
@@ -1104,20 +1120,6 @@ export function angular(options: PluginOptions = {}): Plugin[] {
             // duplicate update.
             if (!(handled && !isDirectStyle && !isDirectTemplate)) {
               resourceCache.delete(normalizedFile)
-              // A single owner file can hold both roles — two components in
-              // one `.ts`, one using the file as its styleUrl and the other as
-              // its templateUrl. Dispatch each owner file at most once here:
-              // the ws send in `dispatchComponentUpdate` is not idempotent, so
-              // running both loops over it would emit two events per class.
-              const dispatchedOwners = new Set<string>()
-              const dispatchOwner = (owner: string) => {
-                if (dispatchedOwners.has(owner)) return
-                dispatchedOwners.add(owner)
-                if (dispatchAllComponentsInFile(owner)) {
-                  debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
-                  handled = true
-                }
-              }
               if (isDirectStyle) {
                 // Refresh dependency registration only for actual styles —
                 // never run HTML templates through the CSS preprocessor
@@ -1126,14 +1128,20 @@ export function angular(options: PluginOptions = {}): Plugin[] {
                 // A style shared by several components updates every one of
                 // them (resourceToComponent is single-valued).
                 for (const owner of styleComponentOwners.get(normalizedFile) ?? []) {
-                  dispatchOwner(owner)
+                  if (dispatchOwner(owner)) {
+                    debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
+                  }
                 }
               }
               if (isDirectTemplate) {
                 // A template shared by several component files updates every
-                // one of them (resourceToComponent is single-valued).
+                // one of them (resourceToComponent is single-valued). Skip an
+                // owner already updated above — one `.ts` can hold both roles,
+                // or reach this file transitively through its style.
                 for (const owner of templateComponentOwners.get(normalizedFile) ?? []) {
-                  dispatchOwner(owner)
+                  if (dispatchOwner(owner, true)) {
+                    debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
+                  }
                 }
               }
             }

--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -1093,12 +1093,31 @@ export function angular(options: PluginOptions = {}): Plugin[] {
             styleComponentOwners.has(normalizedFile) ||
             templateComponentOwners.has(normalizedFile)
           ) {
-            // Stylesheets that only appear as transitive deps of other styles
-            // (never used as a direct styleUrl) were already handled by the
-            // shared-dep branch; skip them here to avoid a duplicate update.
+            // The two decorator roles are independent, not alternatives: one
+            // file can be a styleUrl of one component and a templateUrl of
+            // another, so both owner sets are dispatched (issue #450).
             const isDirectStyle = directStyleUrls.has(normalizedFile)
-            if (!(handled && !isDirectStyle)) {
+            const isDirectTemplate = directTemplateUrls.has(normalizedFile)
+            // Stylesheets that only appear as transitive deps of other styles
+            // (never used as a direct styleUrl or templateUrl) were already
+            // handled by the shared-dep branch; skip them here to avoid a
+            // duplicate update.
+            if (!(handled && !isDirectStyle && !isDirectTemplate)) {
               resourceCache.delete(normalizedFile)
+              // A single owner file can hold both roles — two components in
+              // one `.ts`, one using the file as its styleUrl and the other as
+              // its templateUrl. Dispatch each owner file at most once here:
+              // the ws send in `dispatchComponentUpdate` is not idempotent, so
+              // running both loops over it would emit two events per class.
+              const dispatchedOwners = new Set<string>()
+              const dispatchOwner = (owner: string) => {
+                if (dispatchedOwners.has(owner)) return
+                dispatchedOwners.add(owner)
+                if (dispatchAllComponentsInFile(owner)) {
+                  debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
+                  handled = true
+                }
+              }
               if (isDirectStyle) {
                 // Refresh dependency registration only for actual styles —
                 // never run HTML templates through the CSS preprocessor
@@ -1107,19 +1126,14 @@ export function angular(options: PluginOptions = {}): Plugin[] {
                 // A style shared by several components updates every one of
                 // them (resourceToComponent is single-valued).
                 for (const owner of styleComponentOwners.get(normalizedFile) ?? []) {
-                  if (dispatchAllComponentsInFile(owner)) {
-                    debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
-                    handled = true
-                  }
+                  dispatchOwner(owner)
                 }
-              } else {
+              }
+              if (isDirectTemplate) {
                 // A template shared by several component files updates every
                 // one of them (resourceToComponent is single-valued).
                 for (const owner of templateComponentOwners.get(normalizedFile) ?? []) {
-                  if (dispatchAllComponentsInFile(owner)) {
-                    debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
-                    handled = true
-                  }
+                  dispatchOwner(owner)
                 }
               }
             }


### PR DESCRIPTION
Fixes #450.

## The bug

One file serves two decorator roles: component A lists it in `styleUrls`, component B uses it as `templateUrl`. Editing it updated A only. B kept rendering the old template.

`handleHotUpdate` treated the roles as alternatives:

```
edit dual-role file
  └▶ isDirectStyle? ──yes──▶ style loop: styleComponentOwners   (A dispatched)
                 └──no───▶ template loop: templateComponentOwners (never reached)
```

Pre-existing: before #449 the `else` held `resourceToComponent.get`, equally unreachable.

## Only one transform order reproduces it

Worth recording, because it explains why this hid so long. The population loop tests the **global** role sets, not the component's own role for that dep. So an owner transformed *second* is registered in both owner maps:

| transform order | before this PR |
|---|---|
| style owner first | both dispatch — masked by cross-registration |
| **template owner first** | **style owner only; template owner stale** |

The tests pin both orders. The cross-registration itself is pre-existing and left alone: every dispatched owner does use the file in some role, so the membership is over-broad but never wrong, and the new dedupe keeps it from producing duplicate events.

## The fix

Run the two owner loops independently instead of forking on `isDirectStyle`:

- Add `isDirectTemplate` beside `isDirectStyle`. Not a narrowing versus the old `else`: owner-map population is gated on `directTemplateUrls`, which is add-only, so `templateComponentOwners.has(f)` always implies it.
- Widen the transitive-partial dedupe guard to `handled && !isDirectStyle && !isDirectTemplate`, so a direct template is never skipped.
- Dispatch each owner file at most once across both loops. This is load-bearing, not defensive: `pendingHmrUpdates.add` and `invalidateModule` are idempotent but the `ws.send` is not. Removing the dedupe and re-running the suite produces two events per class for a file that holds both roles.
- `refreshStyleDeps` still runs only under `isDirectStyle` — a template must never enter the CSS preprocessor pipeline.

The dedupe set is scoped to the direct-resource block, so the existing shared-dep plus direct-style double dispatch (pinned by `style-deps-hmr.test.ts:312`) is unchanged.

## Tests

TDD. The repro failed on `faa236c` for the intended reason:

```
× dispatches to the style owner and the template owner of the same file
  AssertionError: expected [ Array(1) ] to include '…@TemplateOwnerComponent'
```

Five tests: the repro (template owner first), the reverse-order pin, exactly-one-event-per-class when one file holds both roles, and two no-regression guards — a plain shared `styleUrl` and a transitive-only partial each still dispatch exactly once per component.

## Verification

234 unit tests pass (229 pre-existing + 5 new), `oxfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01665HouXD8imyMphWe1k7Dx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vite HMR dispatch for component templates and styles. Incorrect dispatch can leave the UI stale or send duplicate updates, but this is dev-only and does not touch auth or production builds.
> 
> **Overview**
> Fixes Angular HMR when one resource is both a `styleUrl` and a `templateUrl` (issue #450). Editing that file previously updated only the style owner, so the template owner kept stale markup.
> 
> `handleHotUpdate` no longer treats the two decorator roles as alternatives. It dispatches both owner sets, still skips CSS preprocessing for templates, and sends **at most one** `angular:component-update` per owner file because `ws.send` is not idempotent.
> 
> Tests cover both transform orders, a single `.ts` holding both roles, and no-regression cases for shared styles and transitive Sass partials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe6a4645d75e7a957eb05a0efb262a8f248b28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->