### PR TITLE
fix(vite): send one HMR event per owner file, whatever the reach path

### DIFF
--- a/napi/angular-compiler/test/style-deps-hmr.test.ts
+++ b/napi/angular-compiler/test/style-deps-hmr.test.ts
@@ -656,4 +656,114 @@ describe('handleHotUpdate for a resource reached through both dispatch paths', (
     expect(countOf(`${bothRolesPath}@DualStyleComponent`)).toBe(1)
     expect(countOf(`${bothRolesPath}@DualTemplateComponent`)).toBe(1)
   })
+
+  it('dispatches once per class when a transitive dep is also a direct styleUrl', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // `_shared-style-role.scss` reaches the same owner `.ts` twice:
+    //   - transitively, because `style-role-importer.component.scss` @uses it
+    //   - directly, because a sibling component lists it as its styleUrl
+    // Both roles are style roles, so plain Sass content satisfies both.
+    const partialPath = join(appDir, '_shared-style-role.scss')
+    const importerPath = join(appDir, 'style-role-importer.component.scss')
+    const bothPathsPath = join(appDir, 'style-role-both.component.ts')
+    const transitiveOnlyPath = join(appDir, 'style-role-transitive-only.component.ts')
+
+    writeFileSync(partialPath, 'h1 { color: red; }')
+    writeFileSync(importerPath, "@use './shared-style-role';")
+
+    const bothPathsSource = `
+      import { Component } from '@angular/core';
+
+      @Component({
+        selector: 'app-style-role-transitive',
+        template: '<h1>Hello</h1>',
+        styleUrls: ['./style-role-importer.component.scss'],
+      })
+      export class TransitiveComponent {}
+
+      @Component({
+        selector: 'app-style-role-direct',
+        template: '<h1>Hello</h1>',
+        styleUrls: ['./_shared-style-role.scss'],
+      })
+      export class DirectComponent {}
+    `
+    // Reached ONLY through the shared-dep branch, so its single update proves
+    // that branch really ran.
+    const transitiveOnlySource = componentSource(
+      'app-style-role-only',
+      'style-role-importer.component.scss',
+    )
+
+    writeFileSync(bothPathsPath, bothPathsSource)
+    writeFileSync(transitiveOnlyPath, transitiveOnlySource)
+
+    await transformComponent(plugin, bothPathsSource, bothPathsPath)
+    await transformComponent(plugin, transitiveOnlySource, transitiveOnlyPath)
+
+    writeFileSync(partialPath, 'h1 { color: blue; }')
+    await (plugin.handleHotUpdate as Function).call(
+      plugin,
+      createMockHmrContext(partialPath, mockServer),
+    )
+
+    const ids = mockServer._wsMessages
+      .filter((msg: any) => msg?.event === 'angular:component-update')
+      .map((msg: any) => decodeURIComponent(msg.data.id))
+    const countOf = (id: string) => ids.filter((candidate: string) => candidate === id).length
+
+    // The shared-dep branch ran.
+    expect(countOf(`${transitiveOnlyPath}@AppComponent`)).toBe(1)
+
+    // The dual-path owner is dispatched by the shared-dep branch and again by
+    // the direct-style loop. `ws.send` is not idempotent, so each class must
+    // still see exactly one event.
+    expect(countOf(`${bothPathsPath}@TransitiveComponent`)).toBe(1)
+    expect(countOf(`${bothPathsPath}@DirectComponent`)).toBe(1)
+  })
+
+  it('dispatches once per class when two styles of one component share a partial', async () => {
+    const plugin = getAngularPlugin()
+    const mockServer = await setupPluginWithServer(plugin)
+
+    // Both styleUrls of ONE component @use the same partial, so
+    // `styleDepOwners` holds two owning styles that resolve to the same owner
+    // `.ts`. The shared-dep loop then visits that owner once per style.
+    const partialPath = join(appDir, '_two-styles.scss')
+    const firstStylePath = join(appDir, 'two-styles-a.component.scss')
+    const secondStylePath = join(appDir, 'two-styles-b.component.scss')
+    const ownerPath = join(appDir, 'two-styles.component.ts')
+
+    writeFileSync(partialPath, 'h1 { color: red; }')
+    writeFileSync(firstStylePath, "@use './two-styles';")
+    writeFileSync(secondStylePath, "@use './two-styles';")
+
+    const ownerSource = `
+      import { Component } from '@angular/core';
+
+      @Component({
+        selector: 'app-two-styles',
+        template: '<h1>Hello</h1>',
+        styleUrls: ['./two-styles-a.component.scss', './two-styles-b.component.scss'],
+      })
+      export class TwoStylesComponent {}
+    `
+    writeFileSync(ownerPath, ownerSource)
+
+    await transformComponent(plugin, ownerSource, ownerPath)
+
+    writeFileSync(partialPath, 'h1 { color: blue; }')
+    await (plugin.handleHotUpdate as Function).call(
+      plugin,
+      createMockHmrContext(partialPath, mockServer),
+    )
+
+    const ids = mockServer._wsMessages
+      .filter((msg: any) => msg?.event === 'angular:component-update')
+      .map((msg: any) => decodeURIComponent(msg.data.id))
+
+    expect(ids.filter((id: string) => id === `${ownerPath}@TwoStylesComponent`)).toHaveLength(1)
+  })
 })

--- a/napi/angular-compiler/vite-plugin/index.ts
+++ b/napi/angular-compiler/vite-plugin/index.ts
@@ -1060,16 +1060,19 @@ export function angular(options: PluginOptions = {}): Plugin[] {
           let handled = false
           // Owner files already sent an update during this invocation. The
           // `ws.send` in `dispatchComponentUpdate` is not idempotent, so an
-          // owner reachable through more than one path below would otherwise
-          // emit a second event for every class in it.
+          // owner reached more than once below would otherwise emit a second
+          // event for every class in it (issue #453).
           const dispatchedOwners = new Set<string>()
-          // Dispatch every component in one owner file. `skipIfDispatched` is
-          // set by the template loop alone: role-independent dispatch (#450)
-          // newly lets it run after the shared-dep branch, so it must not
-          // re-send. The style paths record but never skip — their overlap
-          // with the shared-dep branch predates #450 and is tracked in #453.
-          const dispatchOwner = (owner: string, skipIfDispatched = false): boolean => {
-            if (skipIfDispatched && dispatchedOwners.has(owner)) return false
+          // Dispatch every component in one owner file, at most once per
+          // invocation. An owner can be reached several times over: by two of
+          // its own styles sharing a partial, by a partial that is also one of
+          // its direct styleUrls, or by a file it uses in both decorator
+          // roles. Every repeat is redundant — the update is keyed by
+          // `file@class` alone, and the HMR endpoint rereads the component's
+          // resources from disk, so the first event already carries every
+          // change to any of them.
+          const dispatchOwner = (owner: string): boolean => {
+            if (dispatchedOwners.has(owner)) return false
             dispatchedOwners.add(owner)
             if (!dispatchAllComponentsInFile(owner)) return false
             handled = true
@@ -1135,11 +1138,10 @@ export function angular(options: PluginOptions = {}): Plugin[] {
               }
               if (isDirectTemplate) {
                 // A template shared by several component files updates every
-                // one of them (resourceToComponent is single-valued). Skip an
-                // owner already updated above — one `.ts` can hold both roles,
-                // or reach this file transitively through its style.
+                // one of them (resourceToComponent is single-valued). An owner
+                // already updated above is skipped by `dispatchOwner`.
                 for (const owner of templateComponentOwners.get(normalizedFile) ?? []) {
-                  if (dispatchOwner(owner, true)) {
+                  if (dispatchOwner(owner)) {
                     debugHmr('external resource HMR: %s -> %s', normalizedFile, owner)
                   }
                 }


### PR DESCRIPTION
Fixes #453.

## The bug

One owner `.ts` file can be reached more than once in a single `handleHotUpdate` invocation. Each repeat sent another `angular:component-update` for every class in it, because the `ws.send` in `dispatchComponentUpdate` is not idempotent.

Three shapes, all confirmed reproducing before the fix:

| shape | how the owner is reached twice |
|---|---|
| **two styles of one component share a partial** | `styleUrls: ['./a.scss','./b.scss']`, both `@use './shared'` — the shared-dep loop dispatches the owner once per style |
| partial is also a direct `styleUrl` | shared-dep loop, then the direct-style loop |
| file used in both decorator roles | direct-style loop, then the template loop — already deduped in #452 |

The first shape is worth calling out: it needs no cross-branch overlap at all, it duplicates entirely inside one loop, and it is the most ordinary of the three. It was not in the issue text — I went looking for it because the issue's stated case seemed too exotic to be the only one.

## The fix

#452 hoisted the dedupe set above the shared-dep loop but let only the template loop skip, because the style-path overlap predated that work and I did not want to change it inside a bug-fix PR. This is that follow-up: the skip becomes unconditional and the `skipIfDispatched` flag is dropped, since every call site now wants it.

**Every repeat is genuinely redundant.** `dispatchComponentUpdate` derives the queued entry and the payload from `(componentFile, className)` alone — the reaching path contributes nothing, so a repeat is byte-identical apart from the timestamp. The `@ng/component` endpoint then rereads the component's source and **every** one of its `styleUrls` from disk, bypassing `resourceCache`. So one event recompiles the component against all its current resources, which is exactly why the two-styles case is safe to dedupe: a single event picks up both changed styles.

**Cache invalidation is untouched.** `resourceCache.delete` and `refreshStyleDeps` still run on every path, and the outer guard still enters the direct block for a dual-path file — only the dispatch is suppressed. Verified by diff: no `resourceCache`, `refreshStyleDeps`, `isDirectStyle`, or `isDirectTemplate` line changed.

## Tests

TDD; both new tests failed on `0d6599d` with 2 events for the affected class. In variant A the preceding assertion (a transitive-only owner getting exactly 1) passes first, which proves the shared-dep branch fired and the 2 is not the direct loop firing twice.

Regressions re-run in isolation, each named for what it proves:

- `style-deps-hmr.test.ts:338` — two *different* owner files both still update; dedupe is per owner, not per file-pair.
- `style-deps-hmr.test.ts:288` — the 1→2→3 counting test across three separate `handleHotUpdate` calls; proves the set is per-invocation.
- the `Issue #450` block in `hmr-hot-update.test.ts` — both-roles dispatch and its within-block dedupe.
- the #452 dual-path template test.

## Verification

237 unit tests pass (235 pre-existing + 2 new), `oxfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01665HouXD8imyMphWe1k7Dx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Angular component HMR dispatch: over-deduping could miss updates, under-deduping still floods the client. Cache invalidation is unchanged, which keeps the change relatively contained.
> 
> **Overview**
> Stops duplicate `angular:component-update` events when one owner `.ts` is reached more than once in a single `handleHotUpdate` (issue #453). `ws.send` is not idempotent, so repeats previously fired extra events for every class in the file.
> 
> `dispatchOwner` now always skips owners already dispatched in that invocation. The old `skipIfDispatched` flag (template loop only) is gone, so style-path overlap is covered too: two `styleUrls` sharing a Sass partial, a partial that is also a direct `styleUrl`, and dual decorator roles. Cache invalidation and `refreshStyleDeps` still run on every path; only the websocket send is suppressed.
> 
> Adds two HMR tests that assert exactly one event per class for the shared-partial and dual-style-path cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c79e639c6fbb823a041bac68851f46a9b8aed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->