### PR TITLE
0.0.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# Changelog for Oxlint
+# Changelog
 
-See [Oxlint GitHub Release](https://github.com/oxc-project/oxc/releases)
+## 0.0.38 - 2026-08-25
 
-# Changelog for published crates
-
-See each `./crates/*/CHANGELOG.md`
-
-See [summarized release PR](https://github.com/oxc-project/oxc/pulls?q=is%3Apr+is%3Aclosed+release%28crates%29)
+- Fixed template HMR so changes reach every component that shares a template without forcing a full-page reload.
+- Fixed style HMR for shared resources, multiple components in one file, imported resources, and components that remove their last style.
+- Updated Oxc and related dependencies.

--- a/napi/angular-compiler/index.js
+++ b/napi/angular-compiler/index.js
@@ -83,12 +83,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-android-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -106,12 +106,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-android-arm-eabi/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -141,12 +141,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-win32-x64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -164,12 +164,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-win32-x64-msvc/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -188,12 +188,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-win32-ia32-msvc/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -211,12 +211,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-win32-arm64-msvc/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -237,12 +237,12 @@ function requireNative() {
       const bindingPackageVersion =
         require('@oxc-angular/binding-darwin-universal/package.json').version
       if (
-        bindingPackageVersion !== '0.0.37' &&
+        bindingPackageVersion !== '0.0.38' &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+          `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
         )
       }
       return binding
@@ -260,12 +260,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-darwin-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -283,12 +283,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-darwin-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -310,12 +310,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-freebsd-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -333,12 +333,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-freebsd-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -361,12 +361,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-x64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -384,12 +384,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-x64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -409,12 +409,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -432,12 +432,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -457,12 +457,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm-musleabihf/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -480,12 +480,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-arm-gnueabihf/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -505,12 +505,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-loong64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -528,12 +528,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-loong64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -553,12 +553,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-riscv64-musl/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -576,12 +576,12 @@ function requireNative() {
           const bindingPackageVersion =
             require('@oxc-angular/binding-linux-riscv64-gnu/package.json').version
           if (
-            bindingPackageVersion !== '0.0.37' &&
+            bindingPackageVersion !== '0.0.38' &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
           return binding
@@ -600,12 +600,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-linux-ppc64-gnu/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -623,12 +623,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-linux-s390x-gnu/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -650,12 +650,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-arm64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -673,12 +673,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-x64/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -696,12 +696,12 @@ function requireNative() {
         const bindingPackageVersion =
           require('@oxc-angular/binding-openharmony-arm/package.json').version
         if (
-          bindingPackageVersion !== '0.0.37' &&
+          bindingPackageVersion !== '0.0.38' &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0'
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           )
         }
         return binding
@@ -844,9 +844,9 @@ if (!nativeBinding || forceWasi) {
         ) {
           const bindingPackageVersion =
             require('@oxc-angular/binding-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '0.0.37') {
+          if (bindingPackageVersion !== '0.0.38') {
             throw new Error(
-              `WASI binding package version mismatch, expected 0.0.37 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `WASI binding package version mismatch, expected 0.0.38 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             )
           }
         }

--- a/napi/angular-compiler/package.json
+++ b/napi/angular-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxc-angular/vite",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Oxc Angular Compiler Vite plugin",
   "keywords": [
     "angular",


### PR DESCRIPTION
## Summary

- release `@oxc-angular/vite` 0.0.38
- update native package version guards
- add a concise changelog for the HMR fixes since 0.0.37

## Validation

- `pnpm --filter ./napi/angular-compiler build:ts`
- `pnpm --filter ./napi/angular-compiler test` (347 passed)
- `cargo check --all-features`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with binding guard string updates; no functional code changes in the diff.
> 
> **Overview**
> **Release 0.0.38** for `@oxc-angular/vite`: bumps the package version and aligns every native/WASI binding version check in `index.js` from `0.0.37` to `0.0.38`.
> 
> The root **CHANGELOG** is rewritten for this release: it documents template and style **HMR fixes** (shared templates, shared styles, multi-component files, imported resources, removing the last style) and notes updated Oxc dependencies—user-facing notes for work shipped since 0.0.37, not new logic in this diff.
> 
> No compiler or Vite plugin behavior changes appear in the diff itself; this is packaging, version guards, and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e81bc93dba2ee1d7d3f7d4e5f369069cacafa55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->